### PR TITLE
fix(ui): add --popover variable to fix transparent background

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -29,6 +29,8 @@ body.resizing * {
   --primary: 215 25% 50%;  /* 柔和灰蓝 */
   --primary-foreground: 45 10% 98%;
   --border: 40 8% 88%;  /* 暖边框 */
+  --popover: 0 0% 100%;  /* 纯白弹出层背景 */
+  --popover-foreground: 40 10% 10%;  /* 弹出层文字颜色 */
 }
 
 .dark {
@@ -41,6 +43,8 @@ body.resizing * {
   --primary: 215 20% 55%;  /* 柔和灰蓝 */
   --primary-foreground: 40 5% 12%;
   --border: 40 5% 22%;  /* 暖边框 */
+  --popover: 40 5% 14%;  /* 暗色弹出层背景（比背景稍亮） */
+  --popover-foreground: 45 8% 85%;  /* 暗色弹出层文字 */
 }
 
 * {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -23,6 +23,10 @@ export default {
           DEFAULT: "hsl(var(--primary))",
           foreground: "hsl(var(--primary-foreground))",
         },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))",
+        },
       },
       animation: {
         "fade-in": "fadeIn 0.2s ease-out",


### PR DESCRIPTION
- define --popover and --popover-foreground in globals.css
- register popover color in tailwind.config.js
- fixes transparent background in slashmenu and 6 other components
- supports both light and dark modes

affected components:
- slashmenu (editor slash command menu)
- annotationpopover (pdf annotation popup)
- selectcell (database single select dropdown)
- multiselectcell (database multi select dropdown)
- tableview (database row menu)
- databasetoolbar (toolbar view/sort menus)
- columnheader (column header menu with nested submenu)