### PR TITLE
feat: 优化文件存储的撤销历史内存管理并调整快速搜索工具的依赖

### DIFF
--- a/src-tauri/src/agent/debug_log.rs
+++ b/src-tauri/src/agent/debug_log.rs
@@ -2,6 +2,8 @@
 //!
 //! 记录 Agent 执行的完整过程到文件
 
+#![allow(dead_code)]
+
 use std::fs::{File, OpenOptions};
 use std::io::Write;
 use std::path::PathBuf;

--- a/src-tauri/src/agent/deep_research/mod.rs
+++ b/src-tauri/src/agent/deep_research/mod.rs
@@ -10,5 +10,3 @@ pub mod crawler;
 
 pub use types::*;
 pub use builder::{build_deep_research_graph, DeepResearchContext};
-pub use tavily::TavilyClient;
-pub use crawler::JinaClient;

--- a/src-tauri/src/agent/deep_research/nodes.rs
+++ b/src-tauri/src/agent/deep_research/nodes.rs
@@ -9,7 +9,7 @@ use crate::agent::llm_client::LlmClient;
 use crate::agent::deep_research::types::*;
 use crate::agent::deep_research::tavily::TavilyClient;
 use crate::agent::deep_research::crawler::JinaClient;
-use crate::langgraph::error::{GraphError, Interrupt};
+use crate::langgraph::error::Interrupt;
 
 /// 节点执行结果
 pub struct NodeResult {

--- a/src-tauri/src/agent/graph/builder.rs
+++ b/src-tauri/src/agent/graph/builder.rs
@@ -5,10 +5,10 @@
 use std::sync::Arc;
 use tauri::AppHandle;
 
-use crate::langgraph::prelude::{StateGraph, CompiledGraph, START, END, GraphError};
+use crate::langgraph::prelude::{StateGraph, CompiledGraph, GraphError};
 use crate::langgraph::error::GraphResult;
 use crate::agent::types::{
-    GraphState, AgentConfig, TaskIntent, AgentStatus, AgentType, AgentEvent,
+    GraphState, AgentConfig, TaskIntent,
 };
 use crate::agent::llm_client::LlmClient;
 use crate::agent::graph::nodes::*;

--- a/src-tauri/src/agent/graph/mod.rs
+++ b/src-tauri/src/agent/graph/mod.rs
@@ -8,4 +8,4 @@ pub mod executor;
 pub mod builder;
 
 pub use executor::GraphExecutor;
-pub use builder::{AgentContext, build_agent_graph, describe_graph};
+pub use builder::{AgentContext, build_agent_graph};

--- a/src-tauri/src/agent/graph/nodes.rs
+++ b/src-tauri/src/agent/graph/nodes.rs
@@ -320,7 +320,7 @@ async fn agent_worker_node(
     app: &AppHandle,
     llm: &LlmClient,
     mut state: GraphState,
-    agent_type: AgentType,
+    _agent_type: AgentType,
     agent_name: &str,
 ) -> Result<NodeResult, String> {
     use crate::agent::note_map::{generate_note_map, extract_mentioned_notes, NoteMapConfig};

--- a/src-tauri/src/agent/mod.rs
+++ b/src-tauri/src/agent/mod.rs
@@ -14,6 +14,4 @@ pub mod messages;
 pub mod debug_log;
 pub mod workspace_layout;
 
-pub use types::*;
 pub use commands::*;
-pub use deep_research::{DeepResearchConfig, DeepResearchRequest, DeepResearchState};

--- a/src-tauri/src/agent/note_map/mod.rs
+++ b/src-tauri/src/agent/note_map/mod.rs
@@ -14,6 +14,5 @@ pub mod ranking;
 pub mod renderer;
 
 pub use types::*;
-pub use parser::*;
 pub use ranking::*;
 pub use renderer::*;

--- a/src-tauri/src/agent/note_map/renderer.rs
+++ b/src-tauri/src/agent/note_map/renderer.rs
@@ -145,10 +145,10 @@ pub async fn generate_note_map(
     mentioned_notes: &[String],
     config: &NoteMapConfig,
 ) -> Result<String, String> {
-    use super::parser::build_note_meta;
+    
     use super::ranking::{rank_notes, RankingConfig};
-    use tokio::fs;
-    use std::path::Path;
+    
+    
     
     // 1. 扫描工作区中的所有 .md 文件
     let mut notes = Vec::new();
@@ -178,7 +178,7 @@ async fn scan_markdown_files(
     notes: &mut Vec<super::types::NoteMeta>,
 ) -> Result<(), String> {
     use tokio::fs;
-    use std::path::Path;
+    
     
     let mut entries = fs::read_dir(current_path)
         .await

--- a/src-tauri/src/agent/tools/fast_search.rs
+++ b/src-tauri/src/agent/tools/fast_search.rs
@@ -1,9 +1,7 @@
 //! Fast Search 子代理 - 类似 Windsurf Fast Context
 //! 通过并行 grep 快速搜索笔记库，不经过 LLM
 
-use std::collections::HashMap;
 use std::path::Path;
-use regex::Regex;
 use walkdir::WalkDir;
 use rayon::prelude::*;
 

--- a/src-tauri/src/agent/tools/mod.rs
+++ b/src-tauri/src/agent/tools/mod.rs
@@ -9,4 +9,3 @@ pub mod fast_search;
 
 pub use registry::*;
 pub use definitions::*;
-pub use fast_search::*;

--- a/src-tauri/src/agent/workspace_layout.rs
+++ b/src-tauri/src/agent/workspace_layout.rs
@@ -173,7 +173,7 @@ async fn collect_entries(
     }
 
     // 添加文件（限制数量）
-    let file_count = files.len();
+    let _file_count = files.len();
     let shown_files: Vec<_> = files.iter().take(config.max_files_per_dir).cloned().collect();
     let hidden_files: Vec<_> = files.iter().skip(config.max_files_per_dir).cloned().collect();
 

--- a/src-tauri/src/langgraph/ablation.rs
+++ b/src-tauri/src/langgraph/ablation.rs
@@ -3,10 +3,12 @@
 //! Provides tools for systematically evaluating the impact of individual
 //! nodes by masking (disabling) them and comparing results.
 
+#![allow(dead_code)]
+
 use std::collections::{HashMap, HashSet};
 use serde::{Serialize, Deserialize};
 
-use crate::langgraph::metrics::{AggregateStats, MetricsCollector, RunMetrics};
+use crate::langgraph::metrics::{AggregateStats, MetricsCollector};
 
 /// Configuration for an ablation experiment
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -352,7 +354,7 @@ impl AblationReport {
     }
 
     fn recommend_for_node(
-        importance: f64,
+        _importance: f64,
         latency_pct: f64,
         token_pct: f64,
         success_impact: f64,

--- a/src-tauri/src/langgraph/executor.rs
+++ b/src-tauri/src/langgraph/executor.rs
@@ -7,7 +7,6 @@
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use std::time::Instant;
 use serde::{Serialize, Deserialize};
 
 use crate::langgraph::constants::{START, END, MAX_ITERATIONS};
@@ -463,7 +462,7 @@ impl<S: GraphState> CompiledGraph<S> {
         &self,
         test_inputs: Vec<S>,
         configs: Vec<ExecutionConfig>,
-        mut state_factory: F,
+        _state_factory: F,
     ) -> Vec<(String, RunMetrics)>
     where
         F: FnMut() -> S,

--- a/src-tauri/src/langgraph/metrics.rs
+++ b/src-tauri/src/langgraph/metrics.rs
@@ -5,7 +5,7 @@
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
+use std::time::Instant;
 use serde::{Serialize, Deserialize};
 
 /// Metrics for a single node execution

--- a/src-tauri/src/langgraph/mod.rs
+++ b/src-tauri/src/langgraph/mod.rs
@@ -77,38 +77,17 @@ pub mod ablation;
 /// Prelude - commonly used types
 pub mod prelude {
     // Core types
-    pub use crate::langgraph::constants::{START, END};
-    pub use crate::langgraph::error::{
-        GraphError, GraphResult,
-        Interrupt, ResumeCommand,
-        interrupt, interrupt_all
-    };
-    pub use crate::langgraph::state::GraphState;
-    pub use crate::langgraph::node::{Node, NodeSpec};
-    pub use crate::langgraph::branch::{Branch, BranchSpec};
+    pub use crate::langgraph::constants::END;
+    pub use crate::langgraph::error::GraphError;
+    
+    
+    
     pub use crate::langgraph::graph::StateGraph;
-    pub use crate::langgraph::executor::{
-        CompiledGraph, Checkpoint, ExecutionResult, 
-        ExecutionConfig, ExecutionResultWithMetrics
-    };
+    pub use crate::langgraph::executor::CompiledGraph;
 
     // Metrics and evaluation
-    pub use crate::langgraph::metrics::{
-        MetricsCollector, RunMetrics, RunMetricsBuilder,
-        NodeMetrics, AggregateStats, NodeAggregateStats
-    };
-    pub use crate::langgraph::evaluator::{
-        Evaluator, EvalResult, EvalContext, EvalDetail,
-        ExactMatchEvaluator, ContainsEvaluator, 
-        ToolCallEvaluator, LatencyEvaluator,
-        TokenBudgetEvaluator, CompositeEvaluator,
-        CustomEvaluator
-    };
-    pub use crate::langgraph::ablation::{
-        AblationConfig, AblationReport, AblationStudyBuilder,
-        TestCase, NodeOverride, NodeContribution, NodeRecommendation,
-        ConfigResult, ConfigComparison
-    };
+    
+    
+    
 }
 
-pub use prelude::*;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 mod commands;
 mod error;
 mod fs;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,6 +2,7 @@
     all(not(debug_assertions), target_os = "windows"),
     windows_subsystem = "windows"
 )]
+#![allow(dead_code)]
 
 mod commands;
 mod fs;

--- a/src-tauri/src/webdav/mod.rs
+++ b/src-tauri/src/webdav/mod.rs
@@ -11,6 +11,3 @@ pub mod sync;
 pub mod commands;
 
 // Re-exports for internal use
-pub(crate) use types::*;
-pub(crate) use client::WebDAVClient;
-pub(crate) use sync::SyncEngine;

--- a/src/editor/CodeMirrorEditor.tsx
+++ b/src/editor/CodeMirrorEditor.tsx
@@ -82,13 +82,13 @@ const editorTheme = EditorView.theme({
   "&": { backgroundColor: "transparent", fontSize: "16px", height: "100%" },
   ".cm-content": { fontFamily: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif", padding: "16px 0", caretColor: "hsl(var(--primary))" },
   ".cm-line": { padding: "0 16px", paddingLeft: "16px", lineHeight: "1.75", position: "relative" },
-  
+
   // 选区颜色（更淡的蓝色）
   ".cm-selectionBackground": { backgroundColor: "rgba(191, 219, 254, 0.25) !important" },
   "&.cm-focused .cm-selectionBackground": { backgroundColor: "rgba(191, 219, 254, 0.35) !important" },
-  
+
   // === 动画核心样式 ===
-  
+
   // 1. 悬挂标记 (Headings) - 绝对定位到左侧，不占用正文空间
   ".cm-formatting-hanging": {
     position: "absolute",
@@ -101,7 +101,7 @@ const editorTheme = EditorView.theme({
     userSelect: "none",
     pointerEvents: "none",
   },
-  
+
   // 2. 行内标记 (Bold, Italic) - 默认隐藏 (收缩)
   ".cm-formatting-inline": {
     display: "inline-flex",
@@ -120,7 +120,7 @@ const editorTheme = EditorView.theme({
     transition: "max-width 0.2s cubic-bezier(0.2, 0, 0.2, 1), opacity 0.15s ease-out, transform 0.15s ease-out",
     pointerEvents: "none",
   },
-  
+
   // 3. 行内标记 - 激活状态 (展开)
   ".cm-formatting-inline-visible": {
     maxWidth: "4ch", // 足够容纳符号
@@ -141,7 +141,7 @@ const editorTheme = EditorView.theme({
     fontFamily: "'JetBrains Mono', monospace",
     transition: "font-size 0.2s ease-out, opacity 0.2s ease-out",
   },
-  
+
   // 块级标记 - 激活状态 (展开)
   ".cm-formatting-block-visible": {
     fontSize: "1em",
@@ -150,18 +150,18 @@ const editorTheme = EditorView.theme({
 
   // === Math 编辑体验 ===
   // 行内公式渲染结果 - 带淡入动画
-  ".cm-math-inline": { 
-    display: "inline-block", 
-    verticalAlign: "middle", 
+  ".cm-math-inline": {
+    display: "inline-block",
+    verticalAlign: "middle",
     cursor: "pointer",
     animation: "mathFadeIn 0.15s ease-out",
   },
   ".cm-math-block": { display: "block", textAlign: "center", padding: "0.5em 0", overflow: "hidden", cursor: "pointer" },
-  
+
   // 编辑模式：源码背景 (淡绿色) - 带淡入动画
-  ".cm-math-source": { 
-    backgroundColor: "rgba(74, 222, 128, 0.15)", 
-    color: "hsl(var(--foreground))", 
+  ".cm-math-source": {
+    backgroundColor: "rgba(74, 222, 128, 0.15)",
+    color: "hsl(var(--foreground))",
     fontFamily: "'JetBrains Mono', monospace",
     borderRadius: "4px",
     padding: "2px 4px",
@@ -170,7 +170,7 @@ const editorTheme = EditorView.theme({
     cursor: "text",
     animation: "mathFadeIn 0.15s ease-out",
   },
-  
+
   // 公式淡入动画关键帧
   "@keyframes mathFadeIn": {
     "from": { opacity: "0", transform: "scale(0.95)" },
@@ -194,7 +194,7 @@ const editorTheme = EditorView.theme({
   // === Table 样式 ===
   ".cm-table-widget": { display: "block", overflowX: "auto", cursor: "text" },
   ".cm-table-source": { fontFamily: "'JetBrains Mono', monospace !important", whiteSpace: "pre", color: "hsl(var(--foreground))", display: "block", overflowX: "auto" },
-  
+
   // 基础 Markdown 样式
   ".cm-header-1": { fontSize: "2em", fontWeight: "700", lineHeight: "1.3", color: "hsl(var(--md-heading, var(--foreground)))" },
   ".cm-header-2": { fontSize: "1.5em", fontWeight: "600", lineHeight: "1.4", color: "hsl(var(--md-heading, var(--foreground)))" },
@@ -218,17 +218,25 @@ const editorTheme = EditorView.theme({
 
 // KaTeX 预渲染缓存：key = `${formula}|${displayMode}`
 const katexCache = new Map<string, string>();
+const MAX_KATEX_CACHE = 500;
 
 // 预渲染公式（在空闲时调用）
 function prerenderMath(formula: string, displayMode: boolean): void {
   const key = `${formula}|${displayMode}`;
   if (katexCache.has(key)) return;
-  
+
+  // 限制缓存大小
+  if (katexCache.size >= MAX_KATEX_CACHE) {
+    // 简单清理：删除前 100 条
+    const keysToDelete = Array.from(katexCache.keys()).slice(0, 100);
+    keysToDelete.forEach(k => katexCache.delete(k));
+  }
+
   try {
-    const html = katex.renderToString(formula, { 
-      displayMode, 
-      throwOnError: false, 
-      strict: false 
+    const html = katex.renderToString(formula, {
+      displayMode,
+      throwOnError: false,
+      strict: false
     });
     katexCache.set(key, html);
   } catch {
@@ -240,21 +248,22 @@ function prerenderMath(formula: string, displayMode: boolean): void {
 let prerenderQueue: { formula: string, displayMode: boolean }[] = [];
 let prerenderScheduled = false;
 
+// 安全的 requestIdleCallback polyfill
+const safeRequestIdleCallback =
+  typeof window !== 'undefined' && 'requestIdleCallback' in window
+    ? (window as typeof window & { requestIdleCallback: (cb: () => void, opts?: { timeout: number }) => number }).requestIdleCallback
+    : (cb: () => void) => setTimeout(cb, 16);
+
 function schedulePrerenderBatch() {
   if (prerenderScheduled || prerenderQueue.length === 0) return;
   prerenderScheduled = true;
-  
-  requestIdleCallback?.(() => {
+
+  safeRequestIdleCallback(() => {
     const batch = prerenderQueue.splice(0, 5); // 每次处理 5 个
     batch.forEach(({ formula, displayMode }) => prerenderMath(formula, displayMode));
     prerenderScheduled = false;
     if (prerenderQueue.length > 0) schedulePrerenderBatch();
-  }, { timeout: 100 }) || setTimeout(() => {
-    const batch = prerenderQueue.splice(0, 5);
-    batch.forEach(({ formula, displayMode }) => prerenderMath(formula, displayMode));
-    prerenderScheduled = false;
-    if (prerenderQueue.length > 0) schedulePrerenderBatch();
-  }, 16);
+  }, { timeout: 100 });
 }
 
 function queuePrerender(formula: string, displayMode: boolean) {
@@ -269,22 +278,22 @@ function queuePrerender(formula: string, displayMode: boolean) {
 class MathWidget extends WidgetType {
   // isPreviewPanel: true = 编辑模式下方的预览面板; false = 预览模式下的替换块
   constructor(readonly formula: string, readonly displayMode: boolean, readonly isPreviewPanel: boolean = false) { super(); }
-  
-  eq(other: MathWidget) { 
-    return other.formula === this.formula && 
-           other.displayMode === this.displayMode && 
-           other.isPreviewPanel === this.isPreviewPanel; 
+
+  eq(other: MathWidget) {
+    return other.formula === this.formula &&
+      other.displayMode === this.displayMode &&
+      other.isPreviewPanel === this.isPreviewPanel;
   }
 
   toDOM() {
     const container = document.createElement(this.displayMode || this.isPreviewPanel ? "div" : "span");
     container.className = this.isPreviewPanel ? "cm-math-preview-panel" : (this.displayMode ? "cm-math-block" : "cm-math-inline");
-    
+
     // 只有非预览面板（即渲染态公式）才添加标记，用于点击检测
     if (!this.isPreviewPanel) {
-        container.dataset.widgetType = "math";
+      container.dataset.widgetType = "math";
     }
-    
+
     // 尝试使用缓存
     const cacheKey = `${this.formula}|${this.displayMode}`;
     const cached = katexCache.get(cacheKey);
@@ -300,10 +309,10 @@ class MathWidget extends WidgetType {
     return container;
   }
 
-  ignoreEvent() { 
+  ignoreEvent() {
     // 渲染态公式：让 CodeMirror 忽略事件，由我们自己的 mousedown handler 处理
     // 预览面板：让事件穿透 (pointer-events: none)
-    return !this.isPreviewPanel; 
+    return !this.isPreviewPanel;
   }
 }
 
@@ -327,21 +336,21 @@ class CodeBlockWidget extends WidgetType {
     const c = document.createElement("div");
     c.className = "cm-code-block-widget relative group rounded-md overflow-hidden border my-2";
     c.dataset.widgetType = "codeblock";
-    c.innerHTML = `<pre class="p-3 m-0 bg-muted/50 overflow-auto text-sm"><code class="hljs font-mono ${this.language ? 'language-'+this.language : ''}"></code></pre>`;
+    c.innerHTML = `<pre class="p-3 m-0 bg-muted/50 overflow-auto text-sm"><code class="hljs font-mono ${this.language ? 'language-' + this.language : ''}"></code></pre>`;
     const codeEl = c.querySelector("code")!;
     if (this.language && lowlight.registered(this.language)) {
-      try { const tree = lowlight.highlight(this.language, this.code); this.hastToDOM(tree.children, codeEl); } catch {}
+      try { const tree = lowlight.highlight(this.language, this.code); this.hastToDOM(tree.children, codeEl); } catch { }
     } else codeEl.textContent = this.code;
     return c;
   }
   hastToDOM(nodes: any[], parent: HTMLElement) {
     for (const node of nodes) {
-      if (node.type==='text') parent.appendChild(document.createTextNode(node.value));
-      else if (node.type==='element') { 
-        const el=document.createElement(node.tagName); 
-        if(node.properties?.className) el.className=node.properties.className.join(' '); 
-        if(node.children) this.hastToDOM(node.children, el); 
-        parent.appendChild(el); 
+      if (node.type === 'text') parent.appendChild(document.createTextNode(node.value));
+      else if (node.type === 'element') {
+        const el = document.createElement(node.tagName);
+        if (node.properties?.className) el.className = node.properties.className.join(' ');
+        if (node.children) this.hastToDOM(node.children, el);
+        parent.appendChild(el);
       }
     }
   }
@@ -355,12 +364,12 @@ class MermaidWidget extends WidgetType {
   toDOM() {
     const container = document.createElement("div");
     container.className = "mermaid-container my-2";
-    
+
     const pre = document.createElement("pre");
     pre.className = "mermaid";
     pre.textContent = this.code;
     container.appendChild(pre);
-    
+
     // 异步渲染 mermaid
     setTimeout(async () => {
       try {
@@ -377,7 +386,7 @@ class MermaidWidget extends WidgetType {
         pre.style.color = 'red';
       }
     }, 0);
-    
+
     return container;
   }
   ignoreEvent() { return true; }
@@ -386,14 +395,14 @@ class MermaidWidget extends WidgetType {
 class CalloutIconWidget extends WidgetType {
   constructor(readonly icon: string) { super(); }
   eq(other: CalloutIconWidget) { return other.icon === this.icon; }
-  toDOM() { const s=document.createElement("span"); s.className="cm-callout-icon"; s.textContent=this.icon; s.style.cssText="margin-right:6px;font-size:1.1em"; return s; }
+  toDOM() { const s = document.createElement("span"); s.className = "cm-callout-icon"; s.textContent = this.icon; s.style.cssText = "margin-right:6px;font-size:1.1em"; return s; }
   ignoreEvent() { return true; }
 }
 
 class VoicePreviewWidget extends WidgetType {
   constructor(readonly text: string) { super(); }
   eq(other: VoicePreviewWidget) { return other.text === this.text; }
-  toDOM() { const s=document.createElement("span"); s.className="cm-voice-preview"; s.textContent=this.text; return s; }
+  toDOM() { const s = document.createElement("span"); s.className = "cm-voice-preview"; s.textContent = this.text; return s; }
   ignoreEvent() { return true; }
 }
 
@@ -406,7 +415,7 @@ class ImageWidget extends WidgetType {
     container.style.cssText = "display:block;margin:8px 0;";
     container.dataset.widgetType = "image";
     container.dataset.imageSrc = this.src;
-    
+
     // 如果显示信息，添加路径提示
     if (this.showInfo) {
       const info = document.createElement("div");
@@ -415,13 +424,13 @@ class ImageWidget extends WidgetType {
       info.textContent = this.src;
       container.appendChild(info);
     }
-    
+
     const img = document.createElement("img");
     img.alt = this.alt;
     img.className = "markdown-image";
     img.loading = "lazy";
     img.style.cssText = "max-width:100%;border-radius:6px;cursor:pointer;";
-    
+
     // 处理图片路径
     if (this.src.startsWith("http") || this.src.startsWith("data:")) {
       // 网络图片或 data URL
@@ -429,21 +438,21 @@ class ImageWidget extends WidgetType {
     } else if (this.vaultPath) {
       // 本地图片：使用 base64 加载
       const normalizedVaultPath = this.vaultPath.replace(/\\/g, '/');
-      const normalizedSrc = this.src.replace(/\\/g, '/').replace(/^\.\//,'');
-      const fullPath = normalizedSrc.startsWith("/") || normalizedSrc.match(/^[A-Za-z]:/) 
-        ? normalizedSrc 
+      const normalizedSrc = this.src.replace(/\\/g, '/').replace(/^\.\//, '');
+      const fullPath = normalizedSrc.startsWith("/") || normalizedSrc.match(/^[A-Za-z]:/)
+        ? normalizedSrc
         : `${normalizedVaultPath}/${normalizedSrc}`;
-      
+
       // 先显示加载中状态
       img.style.opacity = "0.5";
       img.alt = useLocaleStore.getState().t.common.loading;
-      
+
       // 异步加载 base64
       const ext = fullPath.split('.').pop()?.toLowerCase() || 'png';
-      const mimeType = ext === 'jpg' || ext === 'jpeg' ? 'image/jpeg' : 
-                       ext === 'gif' ? 'image/gif' : 
-                       ext === 'webp' ? 'image/webp' : 'image/png';
-      
+      const mimeType = ext === 'jpg' || ext === 'jpeg' ? 'image/jpeg' :
+        ext === 'gif' ? 'image/gif' :
+          ext === 'webp' ? 'image/webp' : 'image/png';
+
       readBinaryFileBase64(fullPath)
         .then(base64 => {
           img.src = `data:${mimeType};base64,${base64}`;
@@ -456,7 +465,7 @@ class ImageWidget extends WidgetType {
           img.style.opacity = "1";
         });
     }
-    
+
     container.appendChild(img);
     return container;
   }
@@ -469,7 +478,7 @@ const shouldShowSource = (state: EditorState, from: number, to: number): boolean
   const shouldCollapse = state.facet(collapseOnSelectionFacet);
   if (!shouldCollapse) return false;
   if (state.field(mouseSelectingField, false)) return false;
-  
+
   // 只要光标范围接触到目标区域（包含边界），就显示源码
   for (const range of state.selection.ranges) {
     if (range.from <= to && range.to >= from) return true;
@@ -487,26 +496,26 @@ const livePreviewPlugin = ViewPlugin.fromClass(class {
   constructor(view: EditorView) { this.decorations = this.build(view); }
   update(u: ViewUpdate) {
     // 文档变化或视口变化：必须重建
-    if (u.docChanged || u.viewportChanged || u.transactions.some(t=>t.reconfigured)) {
+    if (u.docChanged || u.viewportChanged || u.transactions.some(t => t.reconfigured)) {
       this.decorations = this.build(u.view);
       return;
     }
-    
+
     // 拖动状态变化
     const isDragging = u.state.field(mouseSelectingField, false);
     const wasDragging = u.startState.field(mouseSelectingField, false);
-    
+
     // 刚结束拖动：重建
     if (wasDragging && !isDragging) {
       this.decorations = this.build(u.view);
       return;
     }
-    
+
     // 正在拖动：跳过
     if (isDragging) {
       return;
     }
-    
+
     // 普通选择变化：重建
     if (u.selectionSet) {
       this.decorations = this.build(u.view);
@@ -520,18 +529,18 @@ const livePreviewPlugin = ViewPlugin.fromClass(class {
     for (const r of state.selection.ranges) {
       const start = state.doc.lineAt(r.from).number;
       const end = state.doc.lineAt(r.to).number;
-      for(let l=start; l<=end; l++) activeLines.add(l);
+      for (let l = start; l <= end; l++) activeLines.add(l);
     }
     const isDrag = state.field(mouseSelectingField, false);
 
     syntaxTree(state).iterate({
       enter: (node) => {
         if (!["HeaderMark", "EmphasisMark", "StrikethroughMark", "CodeMark", "ListMark", "QuoteMark"].includes(node.name)) return;
-        
+
         const isBlock = ["HeaderMark", "ListMark", "QuoteMark"].includes(node.name);
         const lineNum = state.doc.lineAt(node.from).number;
         const isActiveLine = activeLines.has(lineNum);
-        
+
         if (isBlock) {
           // 标题/列表/引用标记逻辑
           // 块级标记：始终用同一个基础类，活动时加 visible 类
@@ -544,16 +553,16 @@ const livePreviewPlugin = ViewPlugin.fromClass(class {
           if (node.from >= node.to) return;
           // 判断光标是否接触该 Token
           const isTouched = shouldShowSource(state, node.from, node.to);
-          
-          const cls = (isTouched && !isDrag) 
-            ? "cm-formatting-inline cm-formatting-inline-visible" 
+
+          const cls = (isTouched && !isDrag)
+            ? "cm-formatting-inline cm-formatting-inline-visible"
             : "cm-formatting-inline";
-            
+
           d.push(Decoration.mark({ class: cls }).range(node.from, node.to));
         }
       }
     });
-    return Decoration.set(d.sort((a,b)=>a.from-b.from), true);
+    return Decoration.set(d.sort((a, b) => a.from - b.from), true);
   }
   hide(state: EditorState, from: number, to: number, d: any[]) {
     if (from >= to || state.doc.sliceString(from, to).includes('\n')) return;
@@ -571,37 +580,37 @@ const mathStateField = StateField.define<DecorationSet>({
     if (tr.docChanged || tr.reconfigured) {
       return buildMathDecorations(tr.state);
     }
-    
+
     // 拖动选择期间：完全跳过重建，等拖动结束后再更新
     const isDragging = tr.state.field(mouseSelectingField, false);
     const wasDragging = tr.startState.field(mouseSelectingField, false);
-    
+
     // 刚结束拖动：重建一次
     if (wasDragging && !isDragging) {
       return buildMathDecorations(tr.state);
     }
-    
+
     // 正在拖动：跳过
     if (isDragging) {
       return deco;
     }
-    
+
     // 普通选择变化：检查是否触及公式
     if (tr.selection) {
       const oldSel = tr.startState.selection.main;
       const newSel = tr.state.selection.main;
-      const touchesMath = (sel: { from: number, to: number }) => 
-        mathPositionsCache.some(m => 
-          (sel.from >= m.from && sel.from <= m.to) || 
+      const touchesMath = (sel: { from: number, to: number }) =>
+        mathPositionsCache.some(m =>
+          (sel.from >= m.from && sel.from <= m.to) ||
           (sel.to >= m.from && sel.to <= m.to) ||
           (sel.from <= m.from && sel.to >= m.to)
         );
-      if (touchesMath(oldSel) !== touchesMath(newSel) || 
-          (touchesMath(newSel) && (oldSel.from !== newSel.from || oldSel.to !== newSel.to))) {
+      if (touchesMath(oldSel) !== touchesMath(newSel) ||
+        (touchesMath(newSel) && (oldSel.from !== newSel.from || oldSel.to !== newSel.to))) {
         return buildMathDecorations(tr.state);
       }
     }
-    
+
     return deco;
   },
   provide: f => EditorView.decorations.from(f),
@@ -610,22 +619,22 @@ const mathStateField = StateField.define<DecorationSet>({
 function buildMathDecorations(state: EditorState): DecorationSet {
   const decorations: any[] = [];
   const doc = state.doc.toString();
-  const processed: {from:number, to:number}[] = [];
-  
+  const processed: { from: number, to: number }[] = [];
+
   // 更新公式位置缓存
   mathPositionsCache = [];
-  
+
   const blockRegex = /\$\$([\s\S]+?)\$\$/g;
   let match;
   while ((match = blockRegex.exec(doc)) !== null) {
     const from = match.index, to = from + match[0].length;
-    processed.push({from, to});
-    mathPositionsCache.push({from, to}); // 添加到缓存
+    processed.push({ from, to });
+    mathPositionsCache.push({ from, to }); // 添加到缓存
     const formula = match[1].trim();
-    
+
     // 预渲染公式（后台进行）
     queuePrerender(formula, true);
-    
+
     if (shouldShowSource(state, from, to)) {
       // 编辑模式：源码高亮 + 预览面板(Preview Panel)
       decorations.push(Decoration.mark({ class: "cm-math-source" }).range(from, to));
@@ -642,19 +651,19 @@ function buildMathDecorations(state: EditorState): DecorationSet {
   while ((match = inlineRegex.exec(doc)) !== null) {
     const from = match.index, to = from + match[0].length;
     if (processed.some(p => from >= p.from && to <= p.to)) continue;
-    mathPositionsCache.push({from, to}); // 添加到缓存
+    mathPositionsCache.push({ from, to }); // 添加到缓存
     const inlineFormula = match[1].trim();
-    
+
     // 预渲染公式（后台进行）
     queuePrerender(inlineFormula, false);
-    
+
     if (shouldShowSource(state, from, to)) {
-       decorations.push(Decoration.mark({ class: "cm-math-source" }).range(from, to));
+      decorations.push(Decoration.mark({ class: "cm-math-source" }).range(from, to));
     } else {
-       decorations.push(Decoration.replace({ widget: new MathWidget(inlineFormula, false) }).range(from, to));
+      decorations.push(Decoration.replace({ widget: new MathWidget(inlineFormula, false) }).range(from, to));
     }
   }
-  return Decoration.set(decorations.sort((a,b)=>a.from-b.from), true);
+  return Decoration.set(decorations.sort((a, b) => a.from - b.from), true);
 }
 
 // 表格位置缓存
@@ -671,7 +680,7 @@ const tableStateField = StateField.define<DecorationSet>({
     if (tr.selection) {
       const oldSel = tr.startState.selection.main;
       const newSel = tr.state.selection.main;
-      const touches = (sel: { from: number, to: number }) => 
+      const touches = (sel: { from: number, to: number }) =>
         tablePositionsCache.some(t => (sel.from >= t.from && sel.from <= t.to) || (sel.to >= t.from && sel.to <= t.to) || (sel.from <= t.from && sel.to >= t.to));
       if (touches(oldSel) !== touches(newSel) || (touches(newSel) && (oldSel.from !== newSel.from || oldSel.to !== newSel.to))) {
         return buildTableDecorations(tr.state);
@@ -714,7 +723,7 @@ const codeBlockStateField = StateField.define<DecorationSet>({
     if (tr.selection) {
       const oldSel = tr.startState.selection.main;
       const newSel = tr.state.selection.main;
-      const touches = (sel: { from: number, to: number }) => 
+      const touches = (sel: { from: number, to: number }) =>
         codeBlockPositionsCache.some(c => (sel.from >= c.from && sel.from <= c.to) || (sel.to >= c.from && sel.to <= c.to) || (sel.from <= c.from && sel.to >= c.to));
       if (touches(oldSel) !== touches(newSel) || (touches(newSel) && (oldSel.from !== newSel.from || oldSel.to !== newSel.to))) {
         return buildCodeBlockDecorations(tr.state);
@@ -738,7 +747,7 @@ function buildCodeBlockDecorations(state: EditorState): DecorationSet {
         if (lines.length < 2) return;
         const lang = lines[0].replace(/^\s*`{3,}/, "").trim().toLowerCase();
         const code = lines.slice(1, lines.length - 1).join('\n');
-        const widget = lang === 'mermaid' 
+        const widget = lang === 'mermaid'
           ? new MermaidWidget(code)
           : new CodeBlockWidget(code, lang);
         decorations.push(Decoration.replace({ widget, block: true }).range(node.from, node.to));
@@ -762,7 +771,7 @@ const highlightStateField = StateField.define<DecorationSet>({
     if (tr.selection) {
       const oldSel = tr.startState.selection.main;
       const newSel = tr.state.selection.main;
-      const touches = (sel: { from: number, to: number }) => 
+      const touches = (sel: { from: number, to: number }) =>
         highlightPositionsCache.some(h => (sel.from >= h.from && sel.from <= h.to) || (sel.to >= h.from && sel.to <= h.to) || (sel.from <= h.from && sel.to >= h.to));
       if (touches(oldSel) !== touches(newSel) || (touches(newSel) && (oldSel.from !== newSel.from || oldSel.to !== newSel.to))) {
         return buildHighlightDecorations(tr.state);
@@ -779,74 +788,74 @@ function buildHighlightDecorations(state: EditorState): DecorationSet {
   const highlightRegex = /==([^=\n]+)==/g;
   let match;
   const isDrag = state.field(mouseSelectingField, false);
-  
+
   // 更新缓存
   highlightPositionsCache = [];
-  
+
   while ((match = highlightRegex.exec(doc)) !== null) {
     const from = match.index;
     const to = from + match[0].length;
     highlightPositionsCache.push({ from, to });
     const textStart = from + 2;  // 跳过开头的 ==
     const textEnd = to - 2;      // 跳过结尾的 ==
-    
+
     // 检查是否在代码块内
     const lineStart = doc.lastIndexOf('\n', from) + 1;
     const lineText = doc.slice(lineStart, from);
     if (lineText.includes('`')) continue;
-    
+
     const isTouched = shouldShowSource(state, from, to);
-    
+
     // 高亮文本部分始终添加高亮样式
     decorations.push(Decoration.mark({ class: "cm-highlight" }).range(textStart, textEnd));
-    
+
     // == 标记使用与加粗/斜体相同的动画类
-    const markCls = (isTouched && !isDrag) 
-      ? "cm-formatting-inline cm-formatting-inline-visible" 
+    const markCls = (isTouched && !isDrag)
+      ? "cm-formatting-inline cm-formatting-inline-visible"
       : "cm-formatting-inline";
-    
+
     // 开头的 ==
     decorations.push(Decoration.mark({ class: markCls }).range(from, textStart));
     // 结尾的 ==
     decorations.push(Decoration.mark({ class: markCls }).range(textEnd, to));
   }
-  
+
   return Decoration.set(decorations.sort((a, b) => a.from - b.from), true);
 }
 
 // Table Keymap
 const tableKeymap = [
-    {
-        key: "Tab",
-        run: (view: EditorView) => {
-            const { state } = view;
-            const { head } = state.selection.main;
-            const line = state.doc.lineAt(head);
-            if (!line.text.includes("|")) return false;
-            const rest = line.text.slice(head - line.from);
-            const nextPipe = rest.indexOf("|");
-            if (nextPipe !== -1) { view.dispatch({ selection: { anchor: head + nextPipe + 2 } }); return true; }
-            return false;
-        }
-    },
-    {
-        key: "Enter",
-        run: (view: EditorView) => {
-            const { state } = view;
-            const { head } = state.selection.main;
-            const line = state.doc.lineAt(head);
-            if (!line.text.includes("|")) return false;
-            const pipes = (line.text.match(/\|/g) || []).length;
-            if (pipes < 2) return false;
-            const row = "\n" + "|  ".repeat(Math.max(1, pipes - 1)) + "|";
-            view.dispatch({
-              changes: { from: head, insert: row },
-              selection: { anchor: head + 4 },
-              scrollIntoView: true
-            });
-            return true;
-        }
+  {
+    key: "Tab",
+    run: (view: EditorView) => {
+      const { state } = view;
+      const { head } = state.selection.main;
+      const line = state.doc.lineAt(head);
+      if (!line.text.includes("|")) return false;
+      const rest = line.text.slice(head - line.from);
+      const nextPipe = rest.indexOf("|");
+      if (nextPipe !== -1) { view.dispatch({ selection: { anchor: head + nextPipe + 2 } }); return true; }
+      return false;
     }
+  },
+  {
+    key: "Enter",
+    run: (view: EditorView) => {
+      const { state } = view;
+      const { head } = state.selection.main;
+      const line = state.doc.lineAt(head);
+      if (!line.text.includes("|")) return false;
+      const pipes = (line.text.match(/\|/g) || []).length;
+      if (pipes < 2) return false;
+      const row = "\n" + "|  ".repeat(Math.max(1, pipes - 1)) + "|";
+      view.dispatch({
+        changes: { from: head, insert: row },
+        selection: { anchor: head + 4 },
+        scrollIntoView: true
+      });
+      return true;
+    }
+  }
 ];
 
 const wikiLinkStateField = StateField.define<DecorationSet>({
@@ -885,11 +894,11 @@ function buildCalloutDecorations(state: EditorState): DecorationSet {
     const isEmojiType = !/^\w+$/.test(rawType);
     const color = isEmojiType ? "blue" : (CALLOUT_COLORS[type] || "gray");
     const icon = isEmojiType ? rawType : (CALLOUT_ICONS[type] || "📝");
-    const calloutLines = [{from: line.from}];
+    const calloutLines = [{ from: line.from }];
     let nextLineNo = lineNo + 1;
     while (nextLineNo <= doc.lines) {
       const nextLine = doc.line(nextLineNo);
-      if (/^>\s*/.test(nextLine.text) || nextLine.text.trim() === "") { calloutLines.push({from: nextLine.from}); nextLineNo++; } else break;
+      if (/^>\s*/.test(nextLine.text) || nextLine.text.trim() === "") { calloutLines.push({ from: nextLine.from }); nextLineNo++; } else break;
     }
     calloutLines.forEach((l, idx) => {
       let cls = `callout callout-${color}`;
@@ -897,8 +906,8 @@ function buildCalloutDecorations(state: EditorState): DecorationSet {
         cls += " callout-first";
         const hMatch = doc.line(lineNo).text.match(/^(>\s*)(\[![^\]]+\])(\s*)/);
         if (hMatch) {
-            const s = line.from + hMatch[1].length;
-            decorations.push(Decoration.replace({ widget: new CalloutIconWidget(icon) }).range(s, s + hMatch[2].length));
+          const s = line.from + hMatch[1].length;
+          decorations.push(Decoration.replace({ widget: new CalloutIconWidget(icon) }).range(s, s + hMatch[2].length));
         }
       }
       if (idx === calloutLines.length - 1) cls += " callout-last";
@@ -906,7 +915,7 @@ function buildCalloutDecorations(state: EditorState): DecorationSet {
     });
     lineNo = nextLineNo;
   }
-  return Decoration.set(decorations.sort((a,b)=>a.from-b.from), true);
+  return Decoration.set(decorations.sort((a, b) => a.from - b.from), true);
 }
 
 // ============ 7. Image StateField ============
@@ -946,7 +955,7 @@ function buildImageDecorations(state: EditorState, vaultPath: string): Decoratio
   const decorations: any[] = [];
   const doc = state.doc.toString();
   const showInfoSet = state.field(imageInfoField, false) || new Set<string>();
-  
+
   // 匹配 Markdown 图片语法 ![alt](src)
   const imageRegex = /!\[([^\]]*)\]\(([^)]+)\)/g;
   let match;
@@ -954,25 +963,25 @@ function buildImageDecorations(state: EditorState, vaultPath: string): Decoratio
     const from = match.index, to = from + match[0].length;
     const alt = match[1];
     const src = match[2];
-    
+
     if (shouldShowSource(state, from, to)) {
       // 编辑模式：显示源码 + 图片预览
       decorations.push(Decoration.mark({ class: "cm-image-source" }).range(from, to));
-      decorations.push(Decoration.widget({ 
-        widget: new ImageWidget(src, alt, true, vaultPath), 
-        side: 1, 
-        block: true 
+      decorations.push(Decoration.widget({
+        widget: new ImageWidget(src, alt, true, vaultPath),
+        side: 1,
+        block: true
       }).range(to));
     } else {
       // 预览模式：替换为图片
       const showInfo = showInfoSet.has(src);
-      decorations.push(Decoration.replace({ 
-        widget: new ImageWidget(src, alt, showInfo, vaultPath), 
-        block: true 
+      decorations.push(Decoration.replace({
+        widget: new ImageWidget(src, alt, showInfo, vaultPath),
+        block: true
       }).range(from, to));
     }
   }
-  return Decoration.set(decorations.sort((a,b)=>a.from-b.from), true);
+  return Decoration.set(decorations.sort((a, b) => a.from - b.from), true);
 }
 
 const readingModePlugin = ViewPlugin.fromClass(class {
@@ -1007,9 +1016,9 @@ const markdownStylePlugin = ViewPlugin.fromClass(class {
     syntaxTree(view.state).iterate({
       enter: (node) => {
         const type = node.name;
-        const map: Record<string, string> = { 
-          "ATXHeading1": "cm-header-1", "ATXHeading2": "cm-header-2", "ATXHeading3": "cm-header-3", "ATXHeading4": "cm-header-4", 
-          "StrongEmphasis": "cm-strong", "Emphasis": "cm-emphasis", "Strikethrough": "cm-strikethrough", "InlineCode": "cm-code", "Link": "cm-link", "URL": "cm-url" 
+        const map: Record<string, string> = {
+          "ATXHeading1": "cm-header-1", "ATXHeading2": "cm-header-2", "ATXHeading3": "cm-header-3", "ATXHeading4": "cm-header-4",
+          "StrongEmphasis": "cm-strong", "Emphasis": "cm-emphasis", "Strikethrough": "cm-strikethrough", "InlineCode": "cm-code", "Link": "cm-link", "URL": "cm-url"
         };
         if (type.startsWith("ATXHeading")) {
           const cls = map[type] || "cm-header-4";
@@ -1043,7 +1052,7 @@ const voicePreviewField = StateField.define<DecorationSet>({
 
 export const CodeMirrorEditor = forwardRef<CodeMirrorEditorRef, CodeMirrorEditorProps>(
   function CodeMirrorEditor({ content, onChange, className = "", viewMode, livePreview }, ref) {
-    
+
     const effectiveMode: ViewMode = viewMode ?? (livePreview === false ? 'source' : 'live');
     const isReadOnly = effectiveMode === 'reading';
 
@@ -1055,7 +1064,7 @@ export const CodeMirrorEditor = forwardRef<CodeMirrorEditorRef, CodeMirrorEditor
     const { openVideoNoteTab, openPDFTab, fileTree, openFile, vaultPath } = useFileStore();
     const { openSecondaryPdf } = useSplitStore();
     const { setSplitView } = useUIStore();
-    
+
     const getModeExtensions = useCallback((mode: ViewMode) => {
       const imageField = vaultPath ? createImageStateField(vaultPath) : null;
       const widgets = [mathStateField, tableStateField, codeBlockStateField, calloutStateField, highlightStateField];
@@ -1063,7 +1072,7 @@ export const CodeMirrorEditor = forwardRef<CodeMirrorEditorRef, CodeMirrorEditor
       switch (mode) {
         case 'reading': return [collapseOnSelectionFacet.of(false), readingModePlugin, ...widgets];
         case 'live': return [collapseOnSelectionFacet.of(true), livePreviewPlugin, ...widgets];
-        case 'source': default: return [calloutStateField]; 
+        case 'source': default: return [calloutStateField];
       }
     }, [vaultPath]);
 
@@ -1133,40 +1142,40 @@ export const CodeMirrorEditor = forwardRef<CodeMirrorEditorRef, CodeMirrorEditor
         const v = viewRef.current;
         // 从 store 获取最新的 vaultPath
         const currentVaultPath = useFileStore.getState().vaultPath;
-                if (!v || !currentVaultPath) {
-                    return;
+        if (!v || !currentVaultPath) {
+          return;
         }
-        
+
         const items = e.clipboardData?.items;
         if (!items) return;
-        
+
         for (const item of items) {
-                    if (item.type.startsWith('image/')) {
+          if (item.type.startsWith('image/')) {
             e.preventDefault();
-            
+
             const file = item.getAsFile();
             if (!file) continue;
-            
+
             const ext = file.type.split('/')[1] || 'png';
             const timestamp = Date.now();
             const fileName = `image_${timestamp}.${ext}`;
             // Windows 路径处理
             const normalizedVaultPath = currentVaultPath.replace(/\\/g, '/');
             const filePath = `${normalizedVaultPath}/${fileName}`;
-            
+
             try {
               const arrayBuffer = await file.arrayBuffer();
               const data = new Uint8Array(arrayBuffer);
               await writeBinaryFile(filePath, data);
-              
+
               const pos = v.state.selection.main.head;
               const imageMarkdown = `![](${fileName})`;
               v.dispatch({
                 changes: { from: pos, insert: imageMarkdown },
                 selection: { anchor: pos + imageMarkdown.length },
               });
-                          } catch (err) {
-                          }
+            } catch (err) {
+            }
             return;
           }
         }
@@ -1186,7 +1195,7 @@ export const CodeMirrorEditor = forwardRef<CodeMirrorEditorRef, CodeMirrorEditor
             e.preventDefault();
             const currentShowInfo = v.state.field(imageInfoField, false) || new Set<string>();
             const isShowing = currentShowInfo.has(src);
-            
+
             // 如果点击的是路径信息区域，或者已经显示路径信息再次点击 -> 聚焦到源码
             const clickedInfo = target.closest('.cm-image-info');
             if (clickedInfo || isShowing) {
@@ -1198,7 +1207,7 @@ export const CodeMirrorEditor = forwardRef<CodeMirrorEditorRef, CodeMirrorEditor
                 if (match[2] === src) {
                   const pos = match.index;
                   v.focus();
-                  v.dispatch({ 
+                  v.dispatch({
                     selection: { anchor: pos + 2 }, // 定位到 alt 文本位置
                     effects: setImageShowInfo.of({ src, show: false })
                   });
@@ -1216,21 +1225,21 @@ export const CodeMirrorEditor = forwardRef<CodeMirrorEditorRef, CodeMirrorEditor
         // 1. Math/Table/CodeBlock Widget 点击 -> 聚焦源码
         const widgetDom = target.closest('[data-widget-type="math"], [data-widget-type="table"], [data-widget-type="codeblock"]');
         if (widgetDom) {
-           const pos = v.posAtDOM(widgetDom);
-           if (pos !== null) {
-              e.preventDefault();
-              v.focus();
-              v.dispatch({ selection: { anchor: pos + 1 } });
-              return;
-           }
+          const pos = v.posAtDOM(widgetDom);
+          if (pos !== null) {
+            e.preventDefault();
+            v.focus();
+            v.dispatch({ selection: { anchor: pos + 1 } });
+            return;
+          }
         }
-        
+
         // 2. Links
         const link = target.closest('a[href]');
         if (link?.getAttribute('href')?.startsWith('lumina://pdf')) {
           e.preventDefault(); e.stopPropagation();
           const parsed = parseLuminaLink(link.getAttribute('href')!);
-          if (parsed?.file) (e.ctrlKey || e.metaKey) ? (setSplitView(true), openSecondaryPdf(parsed.file, parsed.page||1, parsed.id)) : openPDFTab(parsed.file);
+          if (parsed?.file) (e.ctrlKey || e.metaKey) ? (setSplitView(true), openSecondaryPdf(parsed.file, parsed.page || 1, parsed.id)) : openPDFTab(parsed.file);
           return;
         }
 
@@ -1239,31 +1248,31 @@ export const CodeMirrorEditor = forwardRef<CodeMirrorEditorRef, CodeMirrorEditor
           e.preventDefault(); e.stopPropagation();
           const name = wikiEl.getAttribute("data-wikilink");
           if (name) {
-             const find = (arr: any[]): string|null => { for(const i of arr) { if(!i.is_dir && i.name.replace(".md","").toLowerCase() === name.toLowerCase()) return i.path; if(i.is_dir) { const r = find(i.children); if(r) return r; } } return null; };
-             const path = find(fileTree);
-             path ? openFile(path) : console.log(`Not found: ${name}`);
+            const find = (arr: any[]): string | null => { for (const i of arr) { if (!i.is_dir && i.name.replace(".md", "").toLowerCase() === name.toLowerCase()) return i.path; if (i.is_dir) { const r = find(i.children); if (r) return r; } } return null; };
+            const path = find(fileTree);
+            path ? openFile(path) : console.log(`Not found: ${name}`);
           }
           return;
         }
 
         if ((e.ctrlKey || e.metaKey) && link) {
-           const h = link.getAttribute('href')!;
-           if (h.includes('bilibili') || h.includes('b23.tv')) { e.preventDefault(); e.stopPropagation(); openVideoNoteTab(h); return; }
+          const h = link.getAttribute('href')!;
+          if (h.includes('bilibili') || h.includes('b23.tv')) { e.preventDefault(); e.stopPropagation(); openVideoNoteTab(h); return; }
         }
       };
 
       view.contentDOM.addEventListener('mousedown', handleClick);
       view.contentDOM.addEventListener('paste', handlePaste);
-      return () => { 
+      return () => {
         view.contentDOM.removeEventListener('mousedown', handleMouseDown);
         view.contentDOM.removeEventListener('mousedown', handleClick);
         view.contentDOM.removeEventListener('paste', handlePaste);
         document.removeEventListener('mouseup', handleMouseUp);
-        view.destroy(); 
-        viewRef.current = null; 
+        view.destroy();
+        viewRef.current = null;
       };
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []); 
+    }, []);
 
     useEffect(() => {
       const view = viewRef.current;
@@ -1290,36 +1299,36 @@ export const CodeMirrorEditor = forwardRef<CodeMirrorEditorRef, CodeMirrorEditor
     }, [content]);
 
     useEffect(() => {
-      const onVoiceInt = (e: any) => viewRef.current?.dispatch({ effects: e.detail?.text ? setVoicePreview.of({from: viewRef.current.state.selection.main.head, text: e.detail.text}) : clearVoicePreview.of(null) });
-      const onVoiceFin = (e: any) => { if(e.detail?.text && viewRef.current) { const p = viewRef.current.state.selection.main.head; viewRef.current.dispatch({ changes: {from:p, to:p, insert:e.detail.text}, selection: {anchor: p+e.detail.text.length}, effects: clearVoicePreview.of(null) }); }};
+      const onVoiceInt = (e: any) => viewRef.current?.dispatch({ effects: e.detail?.text ? setVoicePreview.of({ from: viewRef.current.state.selection.main.head, text: e.detail.text }) : clearVoicePreview.of(null) });
+      const onVoiceFin = (e: any) => { if (e.detail?.text && viewRef.current) { const p = viewRef.current.state.selection.main.head; viewRef.current.dispatch({ changes: { from: p, to: p, insert: e.detail.text }, selection: { anchor: p + e.detail.text.length }, effects: clearVoicePreview.of(null) }); } };
       const onAi = (e: any) => {
-         if(!viewRef.current || !e.detail?.text) return;
-         const {mode, text, description} = e.detail;
-         const s = viewRef.current.state, doc = s.doc.toString(), sel = s.selection.main;
-         let mod = doc;
-         if (mode==="replace_selection") mod = doc.slice(0, sel.from)+text+doc.slice(sel.to);
-         else if (mode==="append_callout") mod = doc.slice(0, sel.to)+text+doc.slice(sel.to);
-         if (mod !== doc) {
-            const f = useFileStore.getState().currentFile;
-            if(f) useAIStore.getState().setPendingDiff({ fileName: f.split('/').pop()!, filePath: f, original: doc, modified: mod, description: description||"AI Edit" });
-         }
+        if (!viewRef.current || !e.detail?.text) return;
+        const { mode, text, description } = e.detail;
+        const s = viewRef.current.state, doc = s.doc.toString(), sel = s.selection.main;
+        let mod = doc;
+        if (mode === "replace_selection") mod = doc.slice(0, sel.from) + text + doc.slice(sel.to);
+        else if (mode === "append_callout") mod = doc.slice(0, sel.to) + text + doc.slice(sel.to);
+        if (mod !== doc) {
+          const f = useFileStore.getState().currentFile;
+          if (f) useAIStore.getState().setPendingDiff({ fileName: f.split('/').pop()!, filePath: f, original: doc, modified: mod, description: description || "AI Edit" });
+        }
       };
-      const onSum = (e: any) => { if(viewRef.current && e.detail?.callout) { const p = viewRef.current.state.selection.main.to; viewRef.current.dispatch({ changes: {from:p, to:p, insert:e.detail.callout}, selection:{anchor:p+e.detail.callout.length} }); }};
+      const onSum = (e: any) => { if (viewRef.current && e.detail?.callout) { const p = viewRef.current.state.selection.main.to; viewRef.current.dispatch({ changes: { from: p, to: p, insert: e.detail.callout }, selection: { anchor: p + e.detail.callout.length } }); } };
 
       // 处理右键菜单格式化
       const onFormat = (e: any) => {
         const view = viewRef.current;
         if (!view || !e.detail?.format) return;
-        
+
         const { format } = e.detail;
         const sel = view.state.selection.main;
         const selectedText = view.state.doc.sliceString(sel.from, sel.to);
-        
+
         if (!selectedText) return;
-        
+
         let replacement = selectedText;
         let cursorOffset = 0;
-        
+
         switch (format) {
           case 'bold':
             replacement = `**${selectedText}**`;
@@ -1376,7 +1385,7 @@ export const CodeMirrorEditor = forwardRef<CodeMirrorEditorRef, CodeMirrorEditor
           default:
             return;
         }
-        
+
         const newPos = sel.from + replacement.length + cursorOffset;
         view.dispatch({
           changes: { from: sel.from, to: sel.to, insert: replacement },
@@ -1384,7 +1393,7 @@ export const CodeMirrorEditor = forwardRef<CodeMirrorEditorRef, CodeMirrorEditor
         });
         view.focus();
       };
-      
+
       window.addEventListener("voice-input-interim", onVoiceInt);
       window.addEventListener("voice-input-final", onVoiceFin);
       window.addEventListener("selection-ai-edit", onAi);
@@ -1406,10 +1415,10 @@ export const CodeMirrorEditor = forwardRef<CodeMirrorEditorRef, CodeMirrorEditor
         const v = viewRef.current;
         const container = containerRef.current;
         if (!v || !container) return;
-        
+
         const rect = container.getBoundingClientRect();
         if (x < rect.left || x > rect.right || y < rect.top || y > rect.bottom) return;
-        
+
         const pos = v.posAtCoords({ x, y }) ?? v.state.selection.main.head;
         v.dispatch({
           changes: { from: pos, insert: wikiLink },
@@ -1417,7 +1426,7 @@ export const CodeMirrorEditor = forwardRef<CodeMirrorEditorRef, CodeMirrorEditor
         });
         v.focus();
       };
-      
+
       window.addEventListener('lumina-drop', handleLuminaDrop);
       return () => window.removeEventListener('lumina-drop', handleLuminaDrop);
     }, []);

--- a/src/stores/useFileStore.memory.test.ts
+++ b/src/stores/useFileStore.memory.test.ts
@@ -1,0 +1,275 @@
+/**
+ * useFileStore 内存分析测试
+ * 
+ * 这些测试用于分析白屏 bug 的根因：
+ * 1. undoStack 存储完整文件内容且无大小限制
+ * 2. Tab 切换时的内存开销
+ * 3. 多 Tab 场景下的内存增长
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock lib/tauri
+vi.mock('@/lib/tauri', () => ({
+    listDirectory: vi.fn(() => Promise.resolve([])),
+    readFile: vi.fn((path: string) => Promise.resolve(`# ${path}\n\nMock content for ${path}`)),
+    saveFile: vi.fn(() => Promise.resolve()),
+    createFile: vi.fn(() => Promise.resolve()),
+}));
+
+import { useFileStore } from './useFileStore';
+
+// 生成指定大小的模拟内容
+function generateContent(sizeKB: number): string {
+    const chars = 'abcdefghijklmnopqrstuvwxyz0123456789 \n';
+    let content = '# Test File\n\n';
+    while (content.length < sizeKB * 1024) {
+        content += chars[Math.floor(Math.random() * chars.length)];
+    }
+    return content;
+}
+
+// 估算对象内存大小（简化版）
+function estimateMemorySize(obj: unknown): number {
+    const str = JSON.stringify(obj);
+    return str.length * 2; // UTF-16 编码，每个字符 2 字节
+}
+
+describe('useFileStore - 内存分析测试', () => {
+    beforeEach(() => {
+        // 重置 store 到初始状态
+        useFileStore.setState({
+            vaultPath: '/mock/vault',
+            fileTree: [],
+            tabs: [],
+            activeTabIndex: -1,
+            currentFile: null,
+            currentContent: '',
+            isDirty: false,
+            isLoadingTree: false,
+            isLoadingFile: false,
+            isSaving: false,
+            undoStack: [],
+            redoStack: [],
+            lastSavedContent: '',
+            navigationHistory: [],
+            navigationIndex: -1,
+            recentFiles: [],
+        });
+        vi.clearAllMocks();
+    });
+
+    describe('undoStack 内存增长分析', () => {
+        it('应该记录每次编辑后的 undoStack 大小', () => {
+            const store = useFileStore.getState();
+            const initialContent = generateContent(10); // 10KB 文件
+
+            // 模拟打开文件
+            useFileStore.setState({
+                currentContent: initialContent,
+                lastSavedContent: initialContent,
+            });
+
+            const memorySizes: number[] = [];
+            const editCount = 50;
+
+            // 模拟 50 次编辑
+            for (let i = 0; i < editCount; i++) {
+                const newContent = initialContent + `\n\nEdit ${i + 1}`;
+                store.updateContent(newContent, 'user');
+
+                const state = useFileStore.getState();
+                const undoStackSize = estimateMemorySize(state.undoStack);
+                memorySizes.push(undoStackSize);
+            }
+
+            // 分析结果
+            const initialSize = memorySizes[0];
+            const finalSize = memorySizes[memorySizes.length - 1];
+            const growthFactor = finalSize / initialSize;
+
+            console.log('\n=== undoStack 内存增长分析 ===');
+            console.log(`文件大小: 10KB`);
+            console.log(`编辑次数: ${editCount}`);
+            console.log(`初始 undoStack 大小: ${(initialSize / 1024).toFixed(2)} KB`);
+            console.log(`最终 undoStack 大小: ${(finalSize / 1024).toFixed(2)} KB`);
+            console.log(`增长倍数: ${growthFactor.toFixed(2)}x`);
+            console.log(`undoStack 条目数: ${useFileStore.getState().undoStack.length}`);
+
+            // 验证：undoStack 数量应该接近编辑次数（考虑 debounce）
+            expect(useFileStore.getState().undoStack.length).toBeGreaterThan(0);
+
+            // 警告：如果增长过快
+            if (growthFactor > 10) {
+                console.warn('⚠️ undoStack 内存增长过快！可能导致内存问题');
+            }
+        });
+
+        it('应该显示 undoStack 无大小限制的问题', () => {
+            const store = useFileStore.getState();
+            const content = generateContent(5); // 5KB 文件
+
+            useFileStore.setState({
+                currentContent: content,
+                lastSavedContent: content,
+            });
+
+            // 模拟大量编辑
+            const editCount = 100;
+            for (let i = 0; i < editCount; i++) {
+                // 添加延迟模拟，让 debounce 生效（通过更改 timestamp）
+                vi.setSystemTime(Date.now() + i * 2000); // 每次编辑间隔 2 秒
+                store.updateContent(content + `\nEdit ${i}`, 'user');
+            }
+
+            const state = useFileStore.getState();
+
+            console.log('\n=== undoStack 无限增长问题 ===');
+            console.log(`undoStack 条目数: ${state.undoStack.length}`);
+            console.log(`理论最大内存: ${(state.undoStack.length * 5).toFixed(0)} KB`);
+
+            // 修复后：undoStack 应该被限制在 50 条以内
+            expect(state.undoStack.length).toBeLessThanOrEqual(50);
+        });
+    });
+
+    describe('多 Tab 内存增长分析', () => {
+        it('应该分析多个 Tab 的总内存占用', async () => {
+            const tabCount = 7; // 用户报告 5-7 个文件就会白屏
+            const fileSize = 10; // KB
+
+            const tabMemorySizes: number[] = [];
+
+            for (let i = 0; i < tabCount; i++) {
+                const content = generateContent(fileSize);
+                const tab = {
+                    id: `tab-${i}`,
+                    type: 'file' as const,
+                    path: `/mock/file${i}.md`,
+                    name: `file${i}`,
+                    content,
+                    isDirty: false,
+                    undoStack: [],
+                    redoStack: [],
+                };
+
+                // 模拟每个 Tab 有一些撤销历史
+                const undoHistory: Array<{ content: string; type: 'user' | 'ai'; timestamp: number }> = [];
+                for (let j = 0; j < 20; j++) {
+                    undoHistory.push({
+                        content: content + `\nEdit ${j}`,
+                        type: 'user',
+                        timestamp: Date.now(),
+                    });
+                }
+                tab.undoStack = undoHistory as typeof tab.undoStack;
+
+                const tabs = [...useFileStore.getState().tabs, tab];
+                useFileStore.setState({ tabs });
+
+                const totalMemory = estimateMemorySize(tabs);
+                tabMemorySizes.push(totalMemory);
+            }
+
+            console.log('\n=== 多 Tab 内存分析 ===');
+            console.log(`Tab 数量: ${tabCount}`);
+            console.log(`每个文件大小: ${fileSize} KB`);
+            console.log(`每个 Tab 撤销历史: 20 条`);
+            tabMemorySizes.forEach((size, i) => {
+                console.log(`${i + 1} 个 Tab: ${(size / 1024 / 1024).toFixed(2)} MB`);
+            });
+            console.log(`最终内存: ${(tabMemorySizes[tabMemorySizes.length - 1] / 1024 / 1024).toFixed(2)} MB`);
+
+            // 估算每个 Tab 的内存
+            // 内容: 10KB + 20 * 10KB (undoStack) = 210KB
+            // 7 个 Tab: ~1.5MB
+            const finalMemory = tabMemorySizes[tabMemorySizes.length - 1];
+            console.log(`\n预估: 7 个 10KB 文件，每个 20 次编辑 -> ${(finalMemory / 1024 / 1024).toFixed(2)} MB`);
+        });
+    });
+
+    describe('Tab 切换内存影响', () => {
+        it('应该分析 Tab 切换时的对象创建', () => {
+            // 创建两个 Tab
+            const content1 = generateContent(5);
+            const content2 = generateContent(5);
+
+            useFileStore.setState({
+                tabs: [
+                    {
+                        id: 'tab-1',
+                        type: 'file',
+                        path: '/file1.md',
+                        name: 'file1',
+                        content: content1,
+                        isDirty: false,
+                        undoStack: [],
+                        redoStack: [],
+                    },
+                    {
+                        id: 'tab-2',
+                        type: 'file',
+                        path: '/file2.md',
+                        name: 'file2',
+                        content: content2,
+                        isDirty: false,
+                        undoStack: [],
+                        redoStack: [],
+                    },
+                ],
+                activeTabIndex: 0,
+                currentFile: '/file1.md',
+                currentContent: content1,
+            });
+
+            const store = useFileStore.getState();
+            const initialTabs = store.tabs;
+
+            // 切换 Tab
+            store.switchTab(1);
+
+            const afterSwitchTabs = useFileStore.getState().tabs;
+
+            // 分析：switchTab 是否创建了新的 tabs 数组
+            const isNewArray = initialTabs !== afterSwitchTabs;
+
+            console.log('\n=== Tab 切换分析 ===');
+            console.log(`切换后是否创建新数组: ${isNewArray}`);
+            console.log(`这意味着每次切换都会触发所有订阅组件重新渲染`);
+
+            // 这是预期行为，但在频繁切换时可能导致性能问题
+            expect(isNewArray).toBe(true);
+        });
+    });
+
+    describe('修复建议验证', () => {
+        it('建议: 限制 undoStack 大小为 50', () => {
+            const MAX_UNDO_HISTORY = 50;
+            const store = useFileStore.getState();
+            const content = generateContent(5);
+
+            useFileStore.setState({
+                currentContent: content,
+                lastSavedContent: content,
+            });
+
+            // 模拟 100 次编辑
+            for (let i = 0; i < 100; i++) {
+                vi.setSystemTime(Date.now() + i * 2000);
+                store.updateContent(content + `\nEdit ${i}`, 'user');
+            }
+
+            const state = useFileStore.getState();
+
+            console.log('\n=== 修复建议验证 ===');
+            console.log(`当前 undoStack 大小: ${state.undoStack.length}`);
+            console.log(`建议最大值: ${MAX_UNDO_HISTORY}`);
+
+            if (state.undoStack.length > MAX_UNDO_HISTORY) {
+                console.log('❌ 当前实现没有限制大小');
+                console.log('建议修复: 在 updateContent 中添加 undoStack.length > 50 时移除最旧记录');
+            } else {
+                console.log('✅ 已实现大小限制');
+            }
+        });
+    });
+});

--- a/src/stores/useFileStore.ts
+++ b/src/stores/useFileStore.ts
@@ -91,7 +91,7 @@ interface FileState {
   updateContent: (content: string, source?: "user" | "ai", description?: string) => void;
   save: () => Promise<void>;
   closeFile: () => void;
-  
+
   // Tab actions
   switchTab: (index: number) => void;
   closeTab: (index: number) => Promise<void>;
@@ -100,10 +100,10 @@ interface FileState {
   reorderTabs: (fromIndex: number, toIndex: number) => void;
   togglePinTab: (index: number) => void;
   updateTabPath: (oldPath: string, newPath: string) => void;
-  
+
   // Create new file
   createNewFile: (fileName?: string) => Promise<void>;
-  
+
   // Open special tabs
   openGraphTab: () => void;
   openIsolatedGraphTab: (node: IsolatedNodeInfo) => void;
@@ -116,7 +116,7 @@ interface FileState {
   updateWebpageTab: (tabId: string, url?: string, title?: string) => void;
   openFlashcardTab: (deckId?: string) => void;
   openCardFlowTab: () => void;
-  
+
   // Undo/Redo actions
   undo: () => void;
   redo: () => void;
@@ -129,10 +129,10 @@ interface FileState {
   goForward: () => void;
   canGoBack: () => boolean;
   canGoForward: () => boolean;
-  
+
   // File sync actions
   reloadFileIfOpen: (path: string) => Promise<void>;
-  
+
   // Workspace actions
   clearVault: () => void;
 }
@@ -141,695 +141,480 @@ interface FileState {
 const USER_EDIT_DEBOUNCE = 1000;
 let lastUserEditTime = 0;
 
+// 撤销历史最大条数（防止内存泄漏）
+const MAX_UNDO_HISTORY = 50;
+
+// 限制 undoStack 大小的辅助函数
+function trimUndoStack(stack: HistoryEntry[]): HistoryEntry[] {
+  if (stack.length <= MAX_UNDO_HISTORY) return stack;
+  // 移除最旧的记录，保留最新的 MAX_UNDO_HISTORY 条
+  return stack.slice(stack.length - MAX_UNDO_HISTORY);
+}
+
 export const useFileStore = create<FileState>()(
   persist(
     (set, get) => ({
-  // Initial state
-  vaultPath: null,
-  fileTree: [],
-  
-  // Tabs
-  tabs: [],
-  activeTabIndex: -1,
-  
-  currentFile: null,
-  currentContent: "",
-  isDirty: false,
-  isLoadingTree: false,
-  isLoadingFile: false,
-  isSaving: false,
-  
-  // Undo/Redo state
-  undoStack: [],
-  redoStack: [],
-  lastSavedContent: "",
+      // Initial state
+      vaultPath: null,
+      fileTree: [],
 
-  // Navigation history
-  navigationHistory: [],
-  navigationIndex: -1,
-  recentFiles: [],
+      // Tabs
+      tabs: [],
+      activeTabIndex: -1,
 
-  // Set vault path and load file tree
-  setVaultPath: async (path: string) => {
-    set({ vaultPath: path, isLoadingTree: true });
-    try {
-      const tree = await listDirectory(path);
-      set({ fileTree: tree, isLoadingTree: false });
-    } catch (error) {
-      console.error("Failed to load vault:", error);
-      set({ isLoadingTree: false });
-    }
-  },
+      currentFile: null,
+      currentContent: "",
+      isDirty: false,
+      isLoadingTree: false,
+      isLoadingFile: false,
+      isSaving: false,
 
-  // Refresh file tree
-  refreshFileTree: async () => {
-    const { vaultPath } = get();
-    if (!vaultPath) return;
+      // Undo/Redo state
+      undoStack: [],
+      redoStack: [],
+      lastSavedContent: "",
 
-    set({ isLoadingTree: true });
-    try {
-      const tree = await listDirectory(vaultPath);
-      set({ fileTree: tree, isLoadingTree: false });
-    } catch (error) {
-      console.error("Failed to refresh file tree:", error);
-      set({ isLoadingTree: false });
-    }
-  },
+      // Navigation history
+      navigationHistory: [],
+      navigationIndex: -1,
+      recentFiles: [],
 
-  // Open a file
-  openFile: async (path: string, addToHistory: boolean = true, forceReload: boolean = false) => {
-    const { tabs, activeTabIndex, navigationHistory, navigationIndex } = get();
-
-    // Normalize paths for comparison (handle Windows backslashes)
-    const normalize = (p: string) => p.replace(/\\/g, "/");
-    const targetPath = normalize(path);
-
-    // 检查是否已经在标签页中打开
-    const existingTabIndex = tabs.findIndex(tab => normalize(tab.path) === targetPath);
-    if (existingTabIndex !== -1) {
-      // 已有此标签页
-      if (forceReload) {
-        // 强制重新加载内容（Agent 编辑后使用）
+      // Set vault path and load file tree
+      setVaultPath: async (path: string) => {
+        set({ vaultPath: path, isLoadingTree: true });
         try {
-          const newContent = await readFile(path);
-          const updatedTabs = [...tabs];
-          updatedTabs[existingTabIndex] = {
-            ...updatedTabs[existingTabIndex],
-            content: newContent,
+          const tree = await listDirectory(path);
+          set({ fileTree: tree, isLoadingTree: false });
+        } catch (error) {
+          console.error("Failed to load vault:", error);
+          set({ isLoadingTree: false });
+        }
+      },
+
+      // Refresh file tree
+      refreshFileTree: async () => {
+        const { vaultPath } = get();
+        if (!vaultPath) return;
+
+        set({ isLoadingTree: true });
+        try {
+          const tree = await listDirectory(vaultPath);
+          set({ fileTree: tree, isLoadingTree: false });
+        } catch (error) {
+          console.error("Failed to refresh file tree:", error);
+          set({ isLoadingTree: false });
+        }
+      },
+
+      // Open a file
+      openFile: async (path: string, addToHistory: boolean = true, forceReload: boolean = false) => {
+        const { tabs, activeTabIndex, navigationHistory, navigationIndex } = get();
+
+        // Normalize paths for comparison (handle Windows backslashes)
+        const normalize = (p: string) => p.replace(/\\/g, "/");
+        const targetPath = normalize(path);
+
+        // 检查是否已经在标签页中打开
+        const existingTabIndex = tabs.findIndex(tab => normalize(tab.path) === targetPath);
+        if (existingTabIndex !== -1) {
+          // 已有此标签页
+          if (forceReload) {
+            // 强制重新加载内容（Agent 编辑后使用）
+            try {
+              const newContent = await readFile(path);
+              const updatedTabs = [...tabs];
+              updatedTabs[existingTabIndex] = {
+                ...updatedTabs[existingTabIndex],
+                content: newContent,
+                isDirty: false,
+              };
+              set({
+                tabs: updatedTabs,
+                activeTabIndex: existingTabIndex,
+                currentFile: path,
+                currentContent: newContent,
+                isDirty: false,
+                lastSavedContent: newContent,
+              });
+            } catch (error) {
+              console.error("Failed to reload file:", error);
+              // 即使重载失败也切换到该标签页
+              get().switchTab(existingTabIndex);
+            }
+          } else {
+            // 直接切换
+            get().switchTab(existingTabIndex);
+          }
+          return;
+        }
+
+        // 保存当前标签页的状态
+        if (activeTabIndex >= 0 && tabs[activeTabIndex]) {
+          const currentTab = tabs[activeTabIndex];
+          if (currentTab.isDirty) {
+            await get().save();
+          }
+        }
+
+        set({ isLoadingFile: true });
+        try {
+          const content = await readFile(path);
+          const fileName = path.split(/[/\\]/).pop()?.replace(/\.md$/, "") || "未命名";
+
+          // 创建新标签页
+          const newTab: Tab = {
+            id: path,
+            type: "file",
+            path,
+            name: fileName,
+            content,
             isDirty: false,
+            undoStack: [],
+            redoStack: [],
           };
+
+          const newTabs = [...tabs, newTab];
+          const newTabIndex = newTabs.length - 1;
+
+          // 更新导航历史
+          let newHistory = navigationHistory;
+          let newNavIndex = navigationIndex;
+
+          if (addToHistory) {
+            newHistory = navigationHistory.slice(0, navigationIndex + 1);
+            newHistory.push(path);
+            newNavIndex = newHistory.length - 1;
+
+            if (newHistory.length > 50) {
+              newHistory = newHistory.slice(-50);
+              newNavIndex = newHistory.length - 1;
+            }
+          }
+
+          // 更新最近文件列表
+          const { recentFiles } = get();
+          let newRecentFiles = recentFiles.filter(p => p !== path);
+          newRecentFiles.push(path);
+          if (newRecentFiles.length > 20) {
+            newRecentFiles = newRecentFiles.slice(-20);
+          }
+
           set({
-            tabs: updatedTabs,
-            activeTabIndex: existingTabIndex,
+            tabs: newTabs,
+            activeTabIndex: newTabIndex,
             currentFile: path,
-            currentContent: newContent,
+            currentContent: content,
             isDirty: false,
-            lastSavedContent: newContent,
+            isLoadingFile: false,
+            undoStack: [],
+            redoStack: [],
+            lastSavedContent: content,
+            navigationHistory: newHistory,
+            navigationIndex: newNavIndex,
+            recentFiles: newRecentFiles,
           });
         } catch (error) {
-          console.error("Failed to reload file:", error);
-          // 即使重载失败也切换到该标签页
-          get().switchTab(existingTabIndex);
+          console.error("Failed to open file:", error);
+          set({ isLoadingFile: false });
         }
-      } else {
-        // 直接切换
-        get().switchTab(existingTabIndex);
-      }
-      return;
-    }
+      },
 
-    // 保存当前标签页的状态
-    if (activeTabIndex >= 0 && tabs[activeTabIndex]) {
-      const currentTab = tabs[activeTabIndex];
-      if (currentTab.isDirty) {
-        await get().save();
-      }
-    }
+      // 切换标签页
+      switchTab: (index: number) => {
+        const { tabs, activeTabIndex, currentContent, isDirty, undoStack, redoStack } = get();
+        if (index < 0 || index >= tabs.length || index === activeTabIndex) return;
 
-    set({ isLoadingFile: true });
-    try {
-      const content = await readFile(path);
-      const fileName = path.split(/[/\\]/).pop()?.replace(/\.md$/, "") || "未命名";
-      
-      // 创建新标签页
-      const newTab: Tab = {
-        id: path,
-        type: "file",
-        path,
-        name: fileName,
-        content,
-        isDirty: false,
-        undoStack: [],
-        redoStack: [],
-      };
-      
-      const newTabs = [...tabs, newTab];
-      const newTabIndex = newTabs.length - 1;
-      
-      // 更新导航历史
-      let newHistory = navigationHistory;
-      let newNavIndex = navigationIndex;
-      
-      if (addToHistory) {
-        newHistory = navigationHistory.slice(0, navigationIndex + 1);
-        newHistory.push(path);
-        newNavIndex = newHistory.length - 1;
-        
-        if (newHistory.length > 50) {
-          newHistory = newHistory.slice(-50);
-          newNavIndex = newHistory.length - 1;
-        }
-      }
-
-      // 更新最近文件列表
-      const { recentFiles } = get();
-      let newRecentFiles = recentFiles.filter(p => p !== path);
-      newRecentFiles.push(path);
-      if (newRecentFiles.length > 20) {
-        newRecentFiles = newRecentFiles.slice(-20);
-      }
-      
-      set({ 
-        tabs: newTabs,
-        activeTabIndex: newTabIndex,
-        currentFile: path,
-        currentContent: content, 
-        isDirty: false, 
-        isLoadingFile: false,
-        undoStack: [],
-        redoStack: [],
-        lastSavedContent: content,
-        navigationHistory: newHistory,
-        navigationIndex: newNavIndex,
-        recentFiles: newRecentFiles,
-      });
-    } catch (error) {
-      console.error("Failed to open file:", error);
-      set({ isLoadingFile: false });
-    }
-  },
-
-  // 切换标签页
-  switchTab: (index: number) => {
-    const { tabs, activeTabIndex, currentContent, isDirty, undoStack, redoStack } = get();
-    if (index < 0 || index >= tabs.length || index === activeTabIndex) return;
-    
-    // 保存当前标签页的状态
-    if (activeTabIndex >= 0 && tabs[activeTabIndex]) {
-      const updatedTabs = [...tabs];
-      updatedTabs[activeTabIndex] = {
-        ...updatedTabs[activeTabIndex],
-        content: currentContent,
-        isDirty,
-        undoStack,
-        redoStack,
-      };
-      
-      // 切换到新标签页
-      const targetTab = updatedTabs[index];
-      set({
-        tabs: updatedTabs,
-        activeTabIndex: index,
-        currentFile: targetTab.path,
-        currentContent: targetTab.content,
-        isDirty: targetTab.isDirty,
-        undoStack: targetTab.undoStack,
-        redoStack: targetTab.redoStack,
-        lastSavedContent: targetTab.content,
-      });
-    } else {
-      // 没有当前标签页，直接切换
-      const targetTab = tabs[index];
-      set({
-        activeTabIndex: index,
-        currentFile: targetTab.path,
-        currentContent: targetTab.content,
-        isDirty: targetTab.isDirty,
-        undoStack: targetTab.undoStack,
-        redoStack: targetTab.redoStack,
-        lastSavedContent: targetTab.content,
-      });
-    }
-  },
-
-  // 关闭标签页
-  closeTab: async (index: number) => {
-    const { tabs, activeTabIndex, currentContent, isDirty, undoStack, redoStack } = get();
-    if (index < 0 || index >= tabs.length) return;
-    
-    const tabToClose = tabs[index];
-    
-    // 固定标签不能关闭
-    if (tabToClose.isPinned) return;
-    
-    // 如果要关闭的是当前标签页且有未保存的更改，先保存
-    if (index === activeTabIndex && isDirty) {
-      await get().save();
-    } else if (tabs[index].isDirty) {
-      // 非当前标签页但有未保存更改，也保存
-      await saveFile(tabs[index].path, tabs[index].content);
-    }
-    
-    // 如果是网页标签页，关闭对应的 WebView
-    if (tabToClose.type === 'webpage') {
-      try {
-        await invoke('close_browser_webview', { tabId: tabToClose.id });
-        console.log('[FileStore] 关闭 WebView:', tabToClose.id);
-      } catch (err) {
-        console.error('[FileStore] 关闭 WebView 失败:', err);
-      }
-    }
-    
-    const newTabs = tabs.filter((_, i) => i !== index);
-    
-    if (newTabs.length === 0) {
-      // 没有标签页了
-      set({
-        tabs: [],
-        activeTabIndex: -1,
-        currentFile: null,
-        currentContent: "",
-        isDirty: false,
-        undoStack: [],
-        redoStack: [],
-      });
-    } else {
-      // 还有其他标签页
-      let newActiveIndex = activeTabIndex;
-      
-      if (index === activeTabIndex) {
-        // 关闭的是当前标签页
-        newActiveIndex = Math.min(index, newTabs.length - 1);
-      } else if (index < activeTabIndex) {
-        // 关闭的是当前标签页前面的
-        newActiveIndex = activeTabIndex - 1;
-      }
-      
-      // 先更新 tabs
-      if (index !== activeTabIndex && activeTabIndex >= 0 && tabs[activeTabIndex]) {
-        // 保存当前标签页状态到新的 tabs 数组
-        const currentTabNewIndex = activeTabIndex > index ? activeTabIndex - 1 : activeTabIndex;
-        if (currentTabNewIndex >= 0 && newTabs[currentTabNewIndex]) {
-          newTabs[currentTabNewIndex] = {
-            ...newTabs[currentTabNewIndex],
+        // 保存当前标签页的状态
+        if (activeTabIndex >= 0 && tabs[activeTabIndex]) {
+          const updatedTabs = [...tabs];
+          updatedTabs[activeTabIndex] = {
+            ...updatedTabs[activeTabIndex],
             content: currentContent,
             isDirty,
             undoStack,
             redoStack,
           };
+
+          // 切换到新标签页
+          const targetTab = updatedTabs[index];
+          set({
+            tabs: updatedTabs,
+            activeTabIndex: index,
+            currentFile: targetTab.path,
+            currentContent: targetTab.content,
+            isDirty: targetTab.isDirty,
+            undoStack: targetTab.undoStack,
+            redoStack: targetTab.redoStack,
+            lastSavedContent: targetTab.content,
+          });
+        } else {
+          // 没有当前标签页，直接切换
+          const targetTab = tabs[index];
+          set({
+            activeTabIndex: index,
+            currentFile: targetTab.path,
+            currentContent: targetTab.content,
+            isDirty: targetTab.isDirty,
+            undoStack: targetTab.undoStack,
+            redoStack: targetTab.redoStack,
+            lastSavedContent: targetTab.content,
+          });
         }
-      }
-      
-      const targetTab = newTabs[newActiveIndex];
-      set({
-        tabs: newTabs,
-        activeTabIndex: newActiveIndex,
-        currentFile: targetTab.path,
-        currentContent: targetTab.content,
-        isDirty: targetTab.isDirty,
-        undoStack: targetTab.undoStack,
-        redoStack: targetTab.redoStack,
-        lastSavedContent: targetTab.content,
-      });
-    }
-  },
+      },
 
-  // 关闭其他标签页（保留固定标签）
-  closeOtherTabs: async (index: number) => {
-    const { tabs } = get();
-    if (index < 0 || index >= tabs.length) return;
-    
-    const targetTab = tabs[index];
-    
-    // 保存所有要关闭的标签页
-    for (const tab of tabs) {
-      if (tab.isDirty && tab.id !== targetTab.id && !tab.isPinned) {
-        await saveFile(tab.path, tab.content);
-      }
-    }
-    
-    // 保留固定标签和当前标签
-    const remainingTabs = tabs.filter(tab => tab.isPinned || tab.id === targetTab.id);
-    const newActiveIndex = remainingTabs.findIndex(t => t.id === targetTab.id);
-    
-    set({
-      tabs: remainingTabs,
-      activeTabIndex: newActiveIndex >= 0 ? newActiveIndex : 0,
-      currentFile: targetTab.path,
-      currentContent: targetTab.content,
-      isDirty: false,
-      undoStack: targetTab.undoStack,
-      redoStack: targetTab.redoStack,
-    });
-  },
+      // 关闭标签页
+      closeTab: async (index: number) => {
+        const { tabs, activeTabIndex, currentContent, isDirty, undoStack, redoStack } = get();
+        if (index < 0 || index >= tabs.length) return;
 
-  // 关闭所有标签页（保留固定标签）
-  closeAllTabs: async () => {
-    const { tabs } = get();
-    
-    // 保存所有要关闭的标签页
-    for (const tab of tabs) {
-      if (tab.isDirty && !tab.isPinned) {
-        await saveFile(tab.path, tab.content);
-      }
-    }
-    
-    // 保留固定标签
-    const pinnedTabs = tabs.filter(tab => tab.isPinned);
-    
-    if (pinnedTabs.length === 0) {
-      set({
-        tabs: [],
-        activeTabIndex: -1,
-        currentFile: null,
-        currentContent: "",
-        isDirty: false,
-        undoStack: [],
-        redoStack: [],
-      });
-    } else {
-      // 切换到第一个固定标签
-      const firstPinned = pinnedTabs[0];
-      set({
-        tabs: pinnedTabs,
-        activeTabIndex: 0,
-        currentFile: firstPinned.path,
-        currentContent: firstPinned.content,
-        isDirty: firstPinned.isDirty,
-        undoStack: firstPinned.undoStack,
-        redoStack: firstPinned.redoStack,
-      });
-    }
-  },
+        const tabToClose = tabs[index];
 
-  // 更新标签页路径（用于文件重命名）
-  updateTabPath: (oldPath: string, newPath: string) => {
-    const { tabs, currentFile } = get();
-    const newFileName = newPath.split(/[/\\/]/).pop()?.replace(/\.md$/, "") || "未命名";
-    
-    // 查找并更新所有匹配的标签页
-    const updatedTabs = tabs.map(tab => {
-      if (tab.type === "file" && tab.path === oldPath) {
-        return {
-          ...tab,
-          path: newPath,
-          name: newFileName,
-          id: newPath, // 更新 id 以匹配新路径
-        };
-      }
-      return tab;
-    });
-    
-    // 如果当前打开的是被重命名的文件，更新 currentFile
-    const newState: Partial<FileState> = { tabs: updatedTabs };
-    if (currentFile === oldPath) {
-      newState.currentFile = newPath;
-    }
-    
-    set(newState);
-  },
+        // 固定标签不能关闭
+        if (tabToClose.isPinned) return;
 
-  // 重新排序标签页
-  reorderTabs: (fromIndex: number, toIndex: number) => {
-    const { tabs, activeTabIndex } = get();
-    if (fromIndex === toIndex) return;
-    if (fromIndex < 0 || fromIndex >= tabs.length) return;
-    if (toIndex < 0 || toIndex >= tabs.length) return;
-    
-    const movedTab = tabs[fromIndex];
-    const pinnedCount = tabs.filter(t => t.isPinned).length;
-    
-    // 固定标签只能在固定区域内移动，非固定标签不能移到固定区域
-    if (movedTab.isPinned) {
-      // 固定标签不能移到非固定区域
-      if (toIndex >= pinnedCount) return;
-    } else {
-      // 非固定标签不能移到固定区域
-      if (toIndex < pinnedCount) return;
-    }
-    
-    const newTabs = [...tabs];
-    newTabs.splice(fromIndex, 1);
-    newTabs.splice(toIndex, 0, movedTab);
-    
-    // 更新活动标签页索引
-    let newActiveIndex = activeTabIndex;
-    if (activeTabIndex === fromIndex) {
-      newActiveIndex = toIndex;
-    } else if (fromIndex < activeTabIndex && toIndex >= activeTabIndex) {
-      newActiveIndex = activeTabIndex - 1;
-    } else if (fromIndex > activeTabIndex && toIndex <= activeTabIndex) {
-      newActiveIndex = activeTabIndex + 1;
-    }
-    
-    set({ tabs: newTabs, activeTabIndex: newActiveIndex });
-  },
+        // 如果要关闭的是当前标签页且有未保存的更改，先保存
+        if (index === activeTabIndex && isDirty) {
+          await get().save();
+        } else if (tabs[index].isDirty) {
+          // 非当前标签页但有未保存更改，也保存
+          await saveFile(tabs[index].path, tabs[index].content);
+        }
 
-  // 固定/取消固定标签页
-  togglePinTab: (index: number) => {
-    const { tabs, activeTabIndex } = get();
-    if (index < 0 || index >= tabs.length) return;
-    
-    const tab = tabs[index];
-    const newIsPinned = !tab.isPinned;
-    const newTabs = [...tabs];
-    
-    // 更新固定状态
-    newTabs[index] = { ...tab, isPinned: newIsPinned };
-    
-    // 重新排序：固定的标签移到最前面
-    const pinnedTabs = newTabs.filter(t => t.isPinned);
-    const unpinnedTabs = newTabs.filter(t => !t.isPinned);
-    const sortedTabs = [...pinnedTabs, ...unpinnedTabs];
-    
-    // 找到当前活动标签在新数组中的位置
-    const activeTabId = tabs[activeTabIndex]?.id;
-    const newActiveIndex = sortedTabs.findIndex(t => t.id === activeTabId);
-    
-    set({ 
-      tabs: sortedTabs, 
-      activeTabIndex: newActiveIndex >= 0 ? newActiveIndex : 0 
-    });
-  },
+        // 如果是网页标签页，关闭对应的 WebView
+        if (tabToClose.type === 'webpage') {
+          try {
+            await invoke('close_browser_webview', { tabId: tabToClose.id });
+            console.log('[FileStore] 关闭 WebView:', tabToClose.id);
+          } catch (err) {
+            console.error('[FileStore] 关闭 WebView 失败:', err);
+          }
+        }
 
-  // 打开图谱标签页
-  openGraphTab: () => {
-    const { tabs, activeTabIndex, currentContent, isDirty, undoStack, redoStack } = get();
-    
-    // 检查是否已经打开
-    const existingIndex = tabs.findIndex(tab => tab.type === "graph");
-    if (existingIndex !== -1) {
-      get().switchTab(existingIndex);
-      return;
-    }
-    
-    // 保存当前标签页状态
-    let updatedTabs = [...tabs];
-    if (activeTabIndex >= 0 && tabs[activeTabIndex]) {
-      updatedTabs[activeTabIndex] = {
-        ...updatedTabs[activeTabIndex],
-        content: currentContent,
-        isDirty,
-        undoStack,
-        redoStack,
-      };
-    }
-    
-    // 创建图谱标签页
-    const graphTab: Tab = {
-      id: "__graph__",
-      type: "graph",
-      path: "",
-      name: "关系图谱",
-      content: "",
-      isDirty: false,
-      undoStack: [],
-      redoStack: [],
-    };
-    
-    updatedTabs.push(graphTab);
-    
-    set({
-      tabs: updatedTabs,
-      activeTabIndex: updatedTabs.length - 1,
-      currentFile: null,
-      currentContent: "",
-      isDirty: false,
-    });
-  },
+        const newTabs = tabs.filter((_, i) => i !== index);
 
-  // 打开主视图区 AI 聊天标签页
-  openAIMainTab: () => {
-    const { tabs, activeTabIndex, currentContent, isDirty, undoStack, redoStack } = get();
+        if (newTabs.length === 0) {
+          // 没有标签页了
+          set({
+            tabs: [],
+            activeTabIndex: -1,
+            currentFile: null,
+            currentContent: "",
+            isDirty: false,
+            undoStack: [],
+            redoStack: [],
+          });
+        } else {
+          // 还有其他标签页
+          let newActiveIndex = activeTabIndex;
 
-    // 如果已经有 ai-chat 标签页，直接切换
-    const existingIndex = tabs.findIndex((tab) => tab.type === "ai-chat");
-    if (existingIndex !== -1) {
-      get().switchTab(existingIndex);
-      return;
-    }
+          if (index === activeTabIndex) {
+            // 关闭的是当前标签页
+            newActiveIndex = Math.min(index, newTabs.length - 1);
+          } else if (index < activeTabIndex) {
+            // 关闭的是当前标签页前面的
+            newActiveIndex = activeTabIndex - 1;
+          }
 
-    // 保存当前标签页状态
-    let updatedTabs = [...tabs];
-    if (activeTabIndex >= 0 && tabs[activeTabIndex]) {
-      updatedTabs[activeTabIndex] = {
-        ...updatedTabs[activeTabIndex],
-        content: currentContent,
-        isDirty,
-        undoStack,
-        redoStack,
-      };
-    }
+          // 先更新 tabs
+          if (index !== activeTabIndex && activeTabIndex >= 0 && tabs[activeTabIndex]) {
+            // 保存当前标签页状态到新的 tabs 数组
+            const currentTabNewIndex = activeTabIndex > index ? activeTabIndex - 1 : activeTabIndex;
+            if (currentTabNewIndex >= 0 && newTabs[currentTabNewIndex]) {
+              newTabs[currentTabNewIndex] = {
+                ...newTabs[currentTabNewIndex],
+                content: currentContent,
+                isDirty,
+                undoStack,
+                redoStack,
+              };
+            }
+          }
 
-    // 创建 AI 聊天标签页
-    const aiTab: Tab = {
-      id: "__ai_chat__",
-      type: "ai-chat",
-      path: "",
-      name: "AI 聊天",
-      content: "",
-      isDirty: false,
-      undoStack: [],
-      redoStack: [],
-    };
+          const targetTab = newTabs[newActiveIndex];
+          set({
+            tabs: newTabs,
+            activeTabIndex: newActiveIndex,
+            currentFile: targetTab.path,
+            currentContent: targetTab.content,
+            isDirty: targetTab.isDirty,
+            undoStack: targetTab.undoStack,
+            redoStack: targetTab.redoStack,
+            lastSavedContent: targetTab.content,
+          });
+        }
+      },
 
-    updatedTabs.push(aiTab);
+      // 关闭其他标签页（保留固定标签）
+      closeOtherTabs: async (index: number) => {
+        const { tabs } = get();
+        if (index < 0 || index >= tabs.length) return;
 
-    set({
-      tabs: updatedTabs,
-      activeTabIndex: updatedTabs.length - 1,
-      currentFile: null,
-      currentContent: "",
-      isDirty: false,
-      undoStack: [],
-      redoStack: [],
-      lastSavedContent: "",
-    });
-  },
+        const targetTab = tabs[index];
 
-  // 打开孤立图谱标签页
-  openIsolatedGraphTab: (node: IsolatedNodeInfo) => {
-    const { tabs, activeTabIndex, currentContent, isDirty, undoStack, redoStack } = get();
-    
-    // 每次都创建新标签页（允许多个孤立视图）
-    const tabId = `__isolated_${node.id}_${Date.now()}__`;
-    
-    // 保存当前标签页状态
-    let updatedTabs = [...tabs];
-    if (activeTabIndex >= 0 && tabs[activeTabIndex]) {
-      updatedTabs[activeTabIndex] = {
-        ...updatedTabs[activeTabIndex],
-        content: currentContent,
-        isDirty,
-        undoStack,
-        redoStack,
-      };
-    }
-    
-    // 创建孤立图谱标签页
-    const isolatedTab: Tab = {
-      id: tabId,
-      type: "isolated-graph",
-      path: node.path,
-      name: `孤立: ${node.label}`,
-      content: "",
-      isDirty: false,
-      undoStack: [],
-      redoStack: [],
-      isolatedNode: node,
-    };
-    
-    updatedTabs.push(isolatedTab);
-    
-    set({
-      tabs: updatedTabs,
-      activeTabIndex: updatedTabs.length - 1,
-      currentFile: null,
-      currentContent: "",
-      isDirty: false,
-    });
-  },
+        // 保存所有要关闭的标签页
+        for (const tab of tabs) {
+          if (tab.isDirty && tab.id !== targetTab.id && !tab.isPinned) {
+            await saveFile(tab.path, tab.content);
+          }
+        }
 
-  // 打开视频笔记标签页（单例模式：只允许一个视频标签页）
-  openVideoNoteTab: (url: string, title?: string) => {
-    const { tabs, activeTabIndex, currentContent, isDirty, undoStack, redoStack } = get();
-    
-    // 检查是否已有视频标签页
-    const existingVideoIndex = tabs.findIndex(t => t.type === "video-note");
-    
-    if (existingVideoIndex >= 0) {
-      // 已有视频标签页，更新 URL 并切换过去
-      const updatedTabs = [...tabs];
-      
-      // 保存当前标签页状态
-      if (activeTabIndex >= 0 && tabs[activeTabIndex]) {
-        updatedTabs[activeTabIndex] = {
-          ...updatedTabs[activeTabIndex],
-          content: currentContent,
-          isDirty,
-          undoStack,
-          redoStack,
-        };
-      }
-      
-      // 提取 BV 号
-      const bvidMatch = url.match(/BV[A-Za-z0-9]+/);
-      const bvid = bvidMatch ? bvidMatch[0] : "";
-      
-      // 更新视频标签页
-      updatedTabs[existingVideoIndex] = {
-        ...updatedTabs[existingVideoIndex],
-        videoUrl: url,
-        name: title || `视频-${bvid}`,
-      };
-      
-      set({
-        tabs: updatedTabs,
-        activeTabIndex: existingVideoIndex,
-        currentFile: null,
-        currentContent: "",
-        isDirty: false,
-      });
-      return;
-    }
-    
-    // 没有视频标签页，创建新的
-    const bvidMatch = url.match(/BV[A-Za-z0-9]+/);
-    const bvid = bvidMatch ? bvidMatch[0] : Date.now().toString();
-    const tabId = `__video_${bvid}__`;
-    
-    // 保存当前标签页状态
-    let updatedTabs = [...tabs];
-    if (activeTabIndex >= 0 && tabs[activeTabIndex]) {
-      updatedTabs[activeTabIndex] = {
-        ...updatedTabs[activeTabIndex],
-        content: currentContent,
-        isDirty,
-        undoStack,
-        redoStack,
-      };
-    }
-    
-    // 创建视频笔记标签页
-    const videoTab: Tab = {
-      id: tabId,
-      type: "video-note",
-      path: "",
-      name: title || `视频-${bvid}`,
-      content: "",
-      isDirty: false,
-      undoStack: [],
-      redoStack: [],
-      videoUrl: url,
-    };
-    
-    updatedTabs.push(videoTab);
-    
-    set({
-      tabs: updatedTabs,
-      activeTabIndex: updatedTabs.length - 1,
-      currentFile: null,
-      currentContent: "",
-      isDirty: false,
-    });
-  },
+        // 保留固定标签和当前标签
+        const remainingTabs = tabs.filter(tab => tab.isPinned || tab.id === targetTab.id);
+        const newActiveIndex = remainingTabs.findIndex(t => t.id === targetTab.id);
 
-  // 从已分享的 Markdown 内容打开视频笔记（支持识别并加载时间戳）
-  openVideoNoteFromContent: (content: string, title?: string) => {
-    const { tabs, activeTabIndex, currentContent, isDirty, undoStack, redoStack } = get();
+        set({
+          tabs: remainingTabs,
+          activeTabIndex: newActiveIndex >= 0 ? newActiveIndex : 0,
+          currentFile: targetTab.path,
+          currentContent: targetTab.content,
+          isDirty: false,
+          undoStack: targetTab.undoStack,
+          redoStack: targetTab.redoStack,
+        });
+      },
 
-    try {
-      const parsed = parseVideoNoteMd(content);
-      if (!parsed) {
-        // 如果不是视频笔记格式，降级为创建空视频标签（不设置数据）
-        get().openVideoNoteTab('', title);
-        return;
-      }
+      // 关闭所有标签页（保留固定标签）
+      closeAllTabs: async () => {
+        const { tabs } = get();
 
-      // 单例视频标签：如果已存在则更新数据并切换
-      const existingVideoIndex = tabs.findIndex(t => t.type === 'video-note');
-      if (existingVideoIndex >= 0) {
-        const updatedTabs = [...tabs];
+        // 保存所有要关闭的标签页
+        for (const tab of tabs) {
+          if (tab.isDirty && !tab.isPinned) {
+            await saveFile(tab.path, tab.content);
+          }
+        }
+
+        // 保留固定标签
+        const pinnedTabs = tabs.filter(tab => tab.isPinned);
+
+        if (pinnedTabs.length === 0) {
+          set({
+            tabs: [],
+            activeTabIndex: -1,
+            currentFile: null,
+            currentContent: "",
+            isDirty: false,
+            undoStack: [],
+            redoStack: [],
+          });
+        } else {
+          // 切换到第一个固定标签
+          const firstPinned = pinnedTabs[0];
+          set({
+            tabs: pinnedTabs,
+            activeTabIndex: 0,
+            currentFile: firstPinned.path,
+            currentContent: firstPinned.content,
+            isDirty: firstPinned.isDirty,
+            undoStack: firstPinned.undoStack,
+            redoStack: firstPinned.redoStack,
+          });
+        }
+      },
+
+      // 更新标签页路径（用于文件重命名）
+      updateTabPath: (oldPath: string, newPath: string) => {
+        const { tabs, currentFile } = get();
+        const newFileName = newPath.split(/[/\\/]/).pop()?.replace(/\.md$/, "") || "未命名";
+
+        // 查找并更新所有匹配的标签页
+        const updatedTabs = tabs.map(tab => {
+          if (tab.type === "file" && tab.path === oldPath) {
+            return {
+              ...tab,
+              path: newPath,
+              name: newFileName,
+              id: newPath, // 更新 id 以匹配新路径
+            };
+          }
+          return tab;
+        });
+
+        // 如果当前打开的是被重命名的文件，更新 currentFile
+        const newState: Partial<FileState> = { tabs: updatedTabs };
+        if (currentFile === oldPath) {
+          newState.currentFile = newPath;
+        }
+
+        set(newState);
+      },
+
+      // 重新排序标签页
+      reorderTabs: (fromIndex: number, toIndex: number) => {
+        const { tabs, activeTabIndex } = get();
+        if (fromIndex === toIndex) return;
+        if (fromIndex < 0 || fromIndex >= tabs.length) return;
+        if (toIndex < 0 || toIndex >= tabs.length) return;
+
+        const movedTab = tabs[fromIndex];
+        const pinnedCount = tabs.filter(t => t.isPinned).length;
+
+        // 固定标签只能在固定区域内移动，非固定标签不能移到固定区域
+        if (movedTab.isPinned) {
+          // 固定标签不能移到非固定区域
+          if (toIndex >= pinnedCount) return;
+        } else {
+          // 非固定标签不能移到固定区域
+          if (toIndex < pinnedCount) return;
+        }
+
+        const newTabs = [...tabs];
+        newTabs.splice(fromIndex, 1);
+        newTabs.splice(toIndex, 0, movedTab);
+
+        // 更新活动标签页索引
+        let newActiveIndex = activeTabIndex;
+        if (activeTabIndex === fromIndex) {
+          newActiveIndex = toIndex;
+        } else if (fromIndex < activeTabIndex && toIndex >= activeTabIndex) {
+          newActiveIndex = activeTabIndex - 1;
+        } else if (fromIndex > activeTabIndex && toIndex <= activeTabIndex) {
+          newActiveIndex = activeTabIndex + 1;
+        }
+
+        set({ tabs: newTabs, activeTabIndex: newActiveIndex });
+      },
+
+      // 固定/取消固定标签页
+      togglePinTab: (index: number) => {
+        const { tabs, activeTabIndex } = get();
+        if (index < 0 || index >= tabs.length) return;
+
+        const tab = tabs[index];
+        const newIsPinned = !tab.isPinned;
+        const newTabs = [...tabs];
+
+        // 更新固定状态
+        newTabs[index] = { ...tab, isPinned: newIsPinned };
+
+        // 重新排序：固定的标签移到最前面
+        const pinnedTabs = newTabs.filter(t => t.isPinned);
+        const unpinnedTabs = newTabs.filter(t => !t.isPinned);
+        const sortedTabs = [...pinnedTabs, ...unpinnedTabs];
+
+        // 找到当前活动标签在新数组中的位置
+        const activeTabId = tabs[activeTabIndex]?.id;
+        const newActiveIndex = sortedTabs.findIndex(t => t.id === activeTabId);
+
+        set({
+          tabs: sortedTabs,
+          activeTabIndex: newActiveIndex >= 0 ? newActiveIndex : 0
+        });
+      },
+
+      // 打开图谱标签页
+      openGraphTab: () => {
+        const { tabs, activeTabIndex, currentContent, isDirty, undoStack, redoStack } = get();
+
+        // 检查是否已经打开
+        const existingIndex = tabs.findIndex(tab => tab.type === "graph");
+        if (existingIndex !== -1) {
+          get().switchTab(existingIndex);
+          return;
+        }
+
+        // 保存当前标签页状态
+        let updatedTabs = [...tabs];
         if (activeTabIndex >= 0 && tabs[activeTabIndex]) {
           updatedTabs[activeTabIndex] = {
             ...updatedTabs[activeTabIndex],
@@ -840,272 +625,43 @@ export const useFileStore = create<FileState>()(
           };
         }
 
-        updatedTabs[existingVideoIndex] = {
-          ...updatedTabs[existingVideoIndex],
-          videoUrl: parsed.video.url,
-          name: title || parsed.video.title || `视频-${parsed.video.bvid}`,
-          videoNoteData: parsed,
-        } as Tab;
+        // 创建图谱标签页
+        const graphTab: Tab = {
+          id: "__graph__",
+          type: "graph",
+          path: "",
+          name: "关系图谱",
+          content: "",
+          isDirty: false,
+          undoStack: [],
+          redoStack: [],
+        };
+
+        updatedTabs.push(graphTab);
 
         set({
           tabs: updatedTabs,
-          activeTabIndex: existingVideoIndex,
+          activeTabIndex: updatedTabs.length - 1,
           currentFile: null,
-          currentContent: '',
+          currentContent: "",
           isDirty: false,
         });
-        return;
-      }
+      },
 
-      // 创建新的 video-note 标签并附带解析后的笔记数据
-      const bvidMatch = parsed.video.bvid ? parsed.video.bvid.match(/BV[A-Za-z0-9]+/) : null;
-      const bvid = bvidMatch ? bvidMatch[0] : Date.now().toString();
-      const tabId = `__video_${bvid}__`;
+      // 打开主视图区 AI 聊天标签页
+      openAIMainTab: () => {
+        const { tabs, activeTabIndex, currentContent, isDirty, undoStack, redoStack } = get();
 
-      let updatedTabs = [...tabs];
-      if (activeTabIndex >= 0 && tabs[activeTabIndex]) {
-        updatedTabs[activeTabIndex] = {
-          ...updatedTabs[activeTabIndex],
-          content: currentContent,
-          isDirty,
-          undoStack,
-          redoStack,
-        };
-      }
+        // 如果已经有 ai-chat 标签页，直接切换
+        const existingIndex = tabs.findIndex((tab) => tab.type === "ai-chat");
+        if (existingIndex !== -1) {
+          get().switchTab(existingIndex);
+          return;
+        }
 
-      const videoTab: Tab = {
-        id: tabId,
-        type: 'video-note',
-        path: '',
-        name: title || parsed.video.title || `视频-${bvid}`,
-        content: '',
-        isDirty: false,
-        undoStack: [],
-        redoStack: [],
-        videoUrl: parsed.video.url,
-        videoNoteData: parsed,
-      };
-
-      updatedTabs.push(videoTab);
-
-      set({
-        tabs: updatedTabs,
-        activeTabIndex: updatedTabs.length - 1,
-        currentFile: null,
-        currentContent: '',
-        isDirty: false,
-      });
-    } catch (error) {
-      console.error('openVideoNoteFromContent failed:', error);
-      // fallback
-      get().openVideoNoteTab('', title);
-    }
-  },
-
-  // 打开数据库标签页
-  openDatabaseTab: (dbId: string, dbName: string) => {
-    const { tabs, activeTabIndex, currentContent, isDirty, undoStack, redoStack } = get();
-    
-    // 检查是否已有此数据库的标签页
-    const existingDbIndex = tabs.findIndex(t => t.type === "database" && t.databaseId === dbId);
-    
-    if (existingDbIndex >= 0) {
-      // 已有此数据库标签页，直接切换
-      let updatedTabs = [...tabs];
-      
-      // 保存当前标签页状态
-      if (activeTabIndex >= 0 && tabs[activeTabIndex]) {
-        updatedTabs[activeTabIndex] = {
-          ...updatedTabs[activeTabIndex],
-          content: currentContent,
-          isDirty,
-          undoStack,
-          redoStack,
-        };
-      }
-      
-      set({
-        tabs: updatedTabs,
-        activeTabIndex: existingDbIndex,
-        currentFile: null,
-        currentContent: "",
-        isDirty: false,
-      });
-      return;
-    }
-    
-    // 创建新数据库标签页
-    const tabId = `__database_${dbId}__`;
-    
-    // 保存当前标签页状态
-    let updatedTabs = [...tabs];
-    if (activeTabIndex >= 0 && tabs[activeTabIndex]) {
-      updatedTabs[activeTabIndex] = {
-        ...updatedTabs[activeTabIndex],
-        content: currentContent,
-        isDirty,
-        undoStack,
-        redoStack,
-      };
-    }
-    
-    // 创建数据库标签页
-    const dbTab: Tab = {
-      id: tabId,
-      type: "database",
-      path: "",
-      name: dbName,
-      content: "",
-      isDirty: false,
-      undoStack: [],
-      redoStack: [],
-      databaseId: dbId,
-    };
-    
-    updatedTabs.push(dbTab);
-    
-    set({
-      tabs: updatedTabs,
-      activeTabIndex: updatedTabs.length - 1,
-      currentFile: null,
-      currentContent: "",
-      isDirty: false,
-    });
-  },
-
-  // 打开 PDF 标签页
-  openPDFTab: (pdfPath: string) => {
-    const { tabs, activeTabIndex, currentContent, isDirty, undoStack, redoStack } = get();
-    
-    // 检查是否已有此 PDF 的标签页
-    const existingPdfIndex = tabs.findIndex(t => t.type === "pdf" && t.path === pdfPath);
-    
-    if (existingPdfIndex >= 0) {
-      // 已有此 PDF 标签页，直接切换
-      let updatedTabs = [...tabs];
-      
-      // 保存当前标签页状态
-      if (activeTabIndex >= 0 && tabs[activeTabIndex]) {
-        updatedTabs[activeTabIndex] = {
-          ...updatedTabs[activeTabIndex],
-          content: currentContent,
-          isDirty,
-          undoStack,
-          redoStack,
-        };
-      }
-      
-      set({
-        tabs: updatedTabs,
-        activeTabIndex: existingPdfIndex,
-        currentFile: pdfPath,
-        currentContent: "",
-        isDirty: false,
-      });
-      return;
-    }
-    
-    // 创建新 PDF 标签页
-    const pdfName = pdfPath.split(/[/\\]/).pop() || "PDF";
-    const tabId = `__pdf_${pdfPath}__`;
-    
-    // 保存当前标签页状态
-    let updatedTabs = [...tabs];
-    if (activeTabIndex >= 0 && tabs[activeTabIndex]) {
-      updatedTabs[activeTabIndex] = {
-        ...updatedTabs[activeTabIndex],
-        content: currentContent,
-        isDirty,
-        undoStack,
-        redoStack,
-      };
-    }
-    
-    // 创建 PDF 标签页
-    const pdfTab: Tab = {
-      id: tabId,
-      type: "pdf",
-      path: pdfPath,
-      name: pdfName,
-      content: "",
-      isDirty: false,
-      undoStack: [],
-      redoStack: [],
-    };
-    
-    updatedTabs.push(pdfTab);
-    
-    set({
-      tabs: updatedTabs,
-      activeTabIndex: updatedTabs.length - 1,
-      currentFile: pdfPath,
-      currentContent: "",
-      isDirty: false,
-    });
-  },
-
-  // 打开卡片流标签页
-  openCardFlowTab: () => {
-    const { tabs, activeTabIndex, currentContent, isDirty, undoStack, redoStack } = get();
-
-    // 检查是否已有 cardflow 标签页
-    const existingIndex = tabs.findIndex((tab) => tab.type === "cardflow");
-    if (existingIndex !== -1) {
-      get().switchTab(existingIndex);
-      return;
-    }
-
-    // 保存当前标签页状态
-    let updatedTabs = [...tabs];
-    if (activeTabIndex >= 0 && tabs[activeTabIndex]) {
-      updatedTabs[activeTabIndex] = {
-        ...updatedTabs[activeTabIndex],
-        content: currentContent,
-        isDirty,
-        undoStack,
-        redoStack,
-      };
-    }
-
-    // 创建卡片流标签页
-    const cardFlowTab: Tab = {
-      id: "__card_flow__",
-      type: "cardflow",
-      path: "",
-      name: "卡片视图",
-      content: "",
-      isDirty: false,
-      undoStack: [],
-      redoStack: [],
-    };
-
-    updatedTabs.push(cardFlowTab);
-
-    set({
-      tabs: updatedTabs,
-      activeTabIndex: updatedTabs.length - 1,
-      currentFile: null,
-      currentContent: "",
-      isDirty: false,
-      undoStack: [],
-      redoStack: [],
-      lastSavedContent: "",
-    });
-  },
-
-  // 打开网页标签页
-  openWebpageTab: (url: string, title?: string) => {
-    const { tabs, activeTabIndex, currentContent, isDirty, undoStack, redoStack, switchTab } = get();
-
-    // 如果已有相同 URL 的网页标签，直接切换过去，避免重复创建
-    if (url) {
-      const existingIndex = tabs.findIndex(
-        (t) => t.type === "webpage" && t.webpageUrl === url
-      );
-      if (existingIndex !== -1) {
-        // 在切换前仍然保存当前标签页状态
+        // 保存当前标签页状态
+        let updatedTabs = [...tabs];
         if (activeTabIndex >= 0 && tabs[activeTabIndex]) {
-          const updatedTabs = [...tabs];
           updatedTabs[activeTabIndex] = {
             ...updatedTabs[activeTabIndex],
             content: currentContent,
@@ -1113,414 +669,871 @@ export const useFileStore = create<FileState>()(
             undoStack,
             redoStack,
           };
-          set({ tabs: updatedTabs });
         }
-        switchTab(existingIndex);
-        return;
-      }
-    }
 
-    // 生成唯一 ID
-    const tabId = `__webpage_${Date.now()}__`;
-    
-    // 保存当前标签页状态
-    let updatedTabs = [...tabs];
-    if (activeTabIndex >= 0 && tabs[activeTabIndex]) {
-      updatedTabs[activeTabIndex] = {
-        ...updatedTabs[activeTabIndex],
-        content: currentContent,
-        isDirty,
-        undoStack,
-        redoStack,
-      };
-    }
-    
-    // 尝试从 URL 提取域名作为默认标题
-    let defaultTitle = title || '新标签页';
-    if (!title && url) {
-      try {
-        const urlObj = new URL(url);
-        defaultTitle = urlObj.hostname;
-      } catch {
-        // 无效 URL，使用默认标题
-      }
-    }
-    
-    // 创建网页标签页
-    const webpageTab: Tab = {
-      id: tabId,
-      type: "webpage",
-      path: "",
-      name: defaultTitle,
-      content: "",
-      isDirty: false,
-      undoStack: [],
-      redoStack: [],
-      webpageUrl: url,
-      webpageTitle: defaultTitle,
-    };
-    
-    updatedTabs.push(webpageTab);
-    
-    set({
-      tabs: updatedTabs,
-      activeTabIndex: updatedTabs.length - 1,
-      currentFile: null,
-      currentContent: "",
-      isDirty: false,
-    });
-  },
-
-  // 更新网页标签页信息
-  updateWebpageTab: (tabId: string, url?: string, title?: string) => {
-    const { tabs } = get();
-    
-    const updatedTabs = tabs.map(tab => {
-      if (tab.id === tabId && tab.type === 'webpage') {
-        return {
-          ...tab,
-          webpageUrl: url ?? tab.webpageUrl,
-          webpageTitle: title ?? tab.webpageTitle,
-          name: title ?? tab.name,
+        // 创建 AI 聊天标签页
+        const aiTab: Tab = {
+          id: "__ai_chat__",
+          type: "ai-chat",
+          path: "",
+          name: "AI 聊天",
+          content: "",
+          isDirty: false,
+          undoStack: [],
+          redoStack: [],
         };
-      }
-      return tab;
-    });
-    
-    set({ tabs: updatedTabs });
-  },
 
-  // 打开闪卡标签页
-  openFlashcardTab: (deckId?: string) => {
-    const { tabs, activeTabIndex, currentContent, isDirty, undoStack, redoStack, switchTab } = get();
+        updatedTabs.push(aiTab);
 
-    // 如果已有闪卡标签页，直接切换
-    const existingIndex = tabs.findIndex(t => t.type === "flashcard");
-    if (existingIndex !== -1) {
-      if (activeTabIndex >= 0 && tabs[activeTabIndex]) {
-        const updatedTabs = [...tabs];
-        updatedTabs[activeTabIndex] = {
-          ...updatedTabs[activeTabIndex],
-          content: currentContent,
-          isDirty,
-          undoStack,
-          redoStack,
+        set({
+          tabs: updatedTabs,
+          activeTabIndex: updatedTabs.length - 1,
+          currentFile: null,
+          currentContent: "",
+          isDirty: false,
+          undoStack: [],
+          redoStack: [],
+          lastSavedContent: "",
+        });
+      },
+
+      // 打开孤立图谱标签页
+      openIsolatedGraphTab: (node: IsolatedNodeInfo) => {
+        const { tabs, activeTabIndex, currentContent, isDirty, undoStack, redoStack } = get();
+
+        // 每次都创建新标签页（允许多个孤立视图）
+        const tabId = `__isolated_${node.id}_${Date.now()}__`;
+
+        // 保存当前标签页状态
+        let updatedTabs = [...tabs];
+        if (activeTabIndex >= 0 && tabs[activeTabIndex]) {
+          updatedTabs[activeTabIndex] = {
+            ...updatedTabs[activeTabIndex],
+            content: currentContent,
+            isDirty,
+            undoStack,
+            redoStack,
+          };
+        }
+
+        // 创建孤立图谱标签页
+        const isolatedTab: Tab = {
+          id: tabId,
+          type: "isolated-graph",
+          path: node.path,
+          name: `孤立: ${node.label}`,
+          content: "",
+          isDirty: false,
+          undoStack: [],
+          redoStack: [],
+          isolatedNode: node,
         };
-        // 更新牌组 ID
-        updatedTabs[existingIndex] = {
-          ...updatedTabs[existingIndex],
-          flashcardDeckId: deckId,
+
+        updatedTabs.push(isolatedTab);
+
+        set({
+          tabs: updatedTabs,
+          activeTabIndex: updatedTabs.length - 1,
+          currentFile: null,
+          currentContent: "",
+          isDirty: false,
+        });
+      },
+
+      // 打开视频笔记标签页（单例模式：只允许一个视频标签页）
+      openVideoNoteTab: (url: string, title?: string) => {
+        const { tabs, activeTabIndex, currentContent, isDirty, undoStack, redoStack } = get();
+
+        // 检查是否已有视频标签页
+        const existingVideoIndex = tabs.findIndex(t => t.type === "video-note");
+
+        if (existingVideoIndex >= 0) {
+          // 已有视频标签页，更新 URL 并切换过去
+          const updatedTabs = [...tabs];
+
+          // 保存当前标签页状态
+          if (activeTabIndex >= 0 && tabs[activeTabIndex]) {
+            updatedTabs[activeTabIndex] = {
+              ...updatedTabs[activeTabIndex],
+              content: currentContent,
+              isDirty,
+              undoStack,
+              redoStack,
+            };
+          }
+
+          // 提取 BV 号
+          const bvidMatch = url.match(/BV[A-Za-z0-9]+/);
+          const bvid = bvidMatch ? bvidMatch[0] : "";
+
+          // 更新视频标签页
+          updatedTabs[existingVideoIndex] = {
+            ...updatedTabs[existingVideoIndex],
+            videoUrl: url,
+            name: title || `视频-${bvid}`,
+          };
+
+          set({
+            tabs: updatedTabs,
+            activeTabIndex: existingVideoIndex,
+            currentFile: null,
+            currentContent: "",
+            isDirty: false,
+          });
+          return;
+        }
+
+        // 没有视频标签页，创建新的
+        const bvidMatch = url.match(/BV[A-Za-z0-9]+/);
+        const bvid = bvidMatch ? bvidMatch[0] : Date.now().toString();
+        const tabId = `__video_${bvid}__`;
+
+        // 保存当前标签页状态
+        let updatedTabs = [...tabs];
+        if (activeTabIndex >= 0 && tabs[activeTabIndex]) {
+          updatedTabs[activeTabIndex] = {
+            ...updatedTabs[activeTabIndex],
+            content: currentContent,
+            isDirty,
+            undoStack,
+            redoStack,
+          };
+        }
+
+        // 创建视频笔记标签页
+        const videoTab: Tab = {
+          id: tabId,
+          type: "video-note",
+          path: "",
+          name: title || `视频-${bvid}`,
+          content: "",
+          isDirty: false,
+          undoStack: [],
+          redoStack: [],
+          videoUrl: url,
         };
-        set({ tabs: updatedTabs });
-      }
-      switchTab(existingIndex);
-      return;
-    }
 
-    // 生成唯一 ID
-    const tabId = `__flashcard_${Date.now()}__`;
-    
-    // 保存当前标签页状态
-    let updatedTabs = [...tabs];
-    if (activeTabIndex >= 0 && tabs[activeTabIndex]) {
-      updatedTabs[activeTabIndex] = {
-        ...updatedTabs[activeTabIndex],
-        content: currentContent,
-        isDirty,
-        undoStack,
-        redoStack,
-      };
-    }
-    
-    // 创建闪卡标签页
-    const flashcardTab: Tab = {
-      id: tabId,
-      type: "flashcard",
-      path: "",
-      name: "闪卡复习",
-      content: "",
-      isDirty: false,
-      undoStack: [],
-      redoStack: [],
-      flashcardDeckId: deckId,
-    };
-    
-    updatedTabs.push(flashcardTab);
-    
-    set({
-      tabs: updatedTabs,
-      activeTabIndex: updatedTabs.length - 1,
-      currentFile: null,
-      currentContent: "",
-      isDirty: false,
-    });
-  },
+        updatedTabs.push(videoTab);
 
-  // 创建新文件
-  createNewFile: async (fileName?: string) => {
-    const { vaultPath, refreshFileTree, openFile } = get();
-    if (!vaultPath) return;
-    
-    const separator = vaultPath.includes("\\") ? "\\" : "/";
-    
-    // 生成文件名
-    let name = fileName;
-    if (!name) {
-      // 生成默认文件名：未命名、未命名 1、未命名 2...
-      const baseName = "未命名";
-      let counter = 0;
-      let finalName = baseName;
-      
-      // 检查文件是否存在
-      const checkPath = () => `${vaultPath}${separator}${finalName}.md`;
-      
-      // 简单检查 - 尝试创建，如果失败则增加计数器
-      while (true) {
+        set({
+          tabs: updatedTabs,
+          activeTabIndex: updatedTabs.length - 1,
+          currentFile: null,
+          currentContent: "",
+          isDirty: false,
+        });
+      },
+
+      // 从已分享的 Markdown 内容打开视频笔记（支持识别并加载时间戳）
+      openVideoNoteFromContent: (content: string, title?: string) => {
+        const { tabs, activeTabIndex, currentContent, isDirty, undoStack, redoStack } = get();
+
         try {
-          await createFile(checkPath());
-          break;
-        } catch {
-          counter++;
-          finalName = `${baseName} ${counter}`;
-          if (counter > 100) {
-            console.error("Too many untitled files");
+          const parsed = parseVideoNoteMd(content);
+          if (!parsed) {
+            // 如果不是视频笔记格式，降级为创建空视频标签（不设置数据）
+            get().openVideoNoteTab('', title);
+            return;
+          }
+
+          // 单例视频标签：如果已存在则更新数据并切换
+          const existingVideoIndex = tabs.findIndex(t => t.type === 'video-note');
+          if (existingVideoIndex >= 0) {
+            const updatedTabs = [...tabs];
+            if (activeTabIndex >= 0 && tabs[activeTabIndex]) {
+              updatedTabs[activeTabIndex] = {
+                ...updatedTabs[activeTabIndex],
+                content: currentContent,
+                isDirty,
+                undoStack,
+                redoStack,
+              };
+            }
+
+            updatedTabs[existingVideoIndex] = {
+              ...updatedTabs[existingVideoIndex],
+              videoUrl: parsed.video.url,
+              name: title || parsed.video.title || `视频-${parsed.video.bvid}`,
+              videoNoteData: parsed,
+            } as Tab;
+
+            set({
+              tabs: updatedTabs,
+              activeTabIndex: existingVideoIndex,
+              currentFile: null,
+              currentContent: '',
+              isDirty: false,
+            });
+            return;
+          }
+
+          // 创建新的 video-note 标签并附带解析后的笔记数据
+          const bvidMatch = parsed.video.bvid ? parsed.video.bvid.match(/BV[A-Za-z0-9]+/) : null;
+          const bvid = bvidMatch ? bvidMatch[0] : Date.now().toString();
+          const tabId = `__video_${bvid}__`;
+
+          let updatedTabs = [...tabs];
+          if (activeTabIndex >= 0 && tabs[activeTabIndex]) {
+            updatedTabs[activeTabIndex] = {
+              ...updatedTabs[activeTabIndex],
+              content: currentContent,
+              isDirty,
+              undoStack,
+              redoStack,
+            };
+          }
+
+          const videoTab: Tab = {
+            id: tabId,
+            type: 'video-note',
+            path: '',
+            name: title || parsed.video.title || `视频-${bvid}`,
+            content: '',
+            isDirty: false,
+            undoStack: [],
+            redoStack: [],
+            videoUrl: parsed.video.url,
+            videoNoteData: parsed,
+          };
+
+          updatedTabs.push(videoTab);
+
+          set({
+            tabs: updatedTabs,
+            activeTabIndex: updatedTabs.length - 1,
+            currentFile: null,
+            currentContent: '',
+            isDirty: false,
+          });
+        } catch (error) {
+          console.error('openVideoNoteFromContent failed:', error);
+          // fallback
+          get().openVideoNoteTab('', title);
+        }
+      },
+
+      // 打开数据库标签页
+      openDatabaseTab: (dbId: string, dbName: string) => {
+        const { tabs, activeTabIndex, currentContent, isDirty, undoStack, redoStack } = get();
+
+        // 检查是否已有此数据库的标签页
+        const existingDbIndex = tabs.findIndex(t => t.type === "database" && t.databaseId === dbId);
+
+        if (existingDbIndex >= 0) {
+          // 已有此数据库标签页，直接切换
+          let updatedTabs = [...tabs];
+
+          // 保存当前标签页状态
+          if (activeTabIndex >= 0 && tabs[activeTabIndex]) {
+            updatedTabs[activeTabIndex] = {
+              ...updatedTabs[activeTabIndex],
+              content: currentContent,
+              isDirty,
+              undoStack,
+              redoStack,
+            };
+          }
+
+          set({
+            tabs: updatedTabs,
+            activeTabIndex: existingDbIndex,
+            currentFile: null,
+            currentContent: "",
+            isDirty: false,
+          });
+          return;
+        }
+
+        // 创建新数据库标签页
+        const tabId = `__database_${dbId}__`;
+
+        // 保存当前标签页状态
+        let updatedTabs = [...tabs];
+        if (activeTabIndex >= 0 && tabs[activeTabIndex]) {
+          updatedTabs[activeTabIndex] = {
+            ...updatedTabs[activeTabIndex],
+            content: currentContent,
+            isDirty,
+            undoStack,
+            redoStack,
+          };
+        }
+
+        // 创建数据库标签页
+        const dbTab: Tab = {
+          id: tabId,
+          type: "database",
+          path: "",
+          name: dbName,
+          content: "",
+          isDirty: false,
+          undoStack: [],
+          redoStack: [],
+          databaseId: dbId,
+        };
+
+        updatedTabs.push(dbTab);
+
+        set({
+          tabs: updatedTabs,
+          activeTabIndex: updatedTabs.length - 1,
+          currentFile: null,
+          currentContent: "",
+          isDirty: false,
+        });
+      },
+
+      // 打开 PDF 标签页
+      openPDFTab: (pdfPath: string) => {
+        const { tabs, activeTabIndex, currentContent, isDirty, undoStack, redoStack } = get();
+
+        // 检查是否已有此 PDF 的标签页
+        const existingPdfIndex = tabs.findIndex(t => t.type === "pdf" && t.path === pdfPath);
+
+        if (existingPdfIndex >= 0) {
+          // 已有此 PDF 标签页，直接切换
+          let updatedTabs = [...tabs];
+
+          // 保存当前标签页状态
+          if (activeTabIndex >= 0 && tabs[activeTabIndex]) {
+            updatedTabs[activeTabIndex] = {
+              ...updatedTabs[activeTabIndex],
+              content: currentContent,
+              isDirty,
+              undoStack,
+              redoStack,
+            };
+          }
+
+          set({
+            tabs: updatedTabs,
+            activeTabIndex: existingPdfIndex,
+            currentFile: pdfPath,
+            currentContent: "",
+            isDirty: false,
+          });
+          return;
+        }
+
+        // 创建新 PDF 标签页
+        const pdfName = pdfPath.split(/[/\\]/).pop() || "PDF";
+        const tabId = `__pdf_${pdfPath}__`;
+
+        // 保存当前标签页状态
+        let updatedTabs = [...tabs];
+        if (activeTabIndex >= 0 && tabs[activeTabIndex]) {
+          updatedTabs[activeTabIndex] = {
+            ...updatedTabs[activeTabIndex],
+            content: currentContent,
+            isDirty,
+            undoStack,
+            redoStack,
+          };
+        }
+
+        // 创建 PDF 标签页
+        const pdfTab: Tab = {
+          id: tabId,
+          type: "pdf",
+          path: pdfPath,
+          name: pdfName,
+          content: "",
+          isDirty: false,
+          undoStack: [],
+          redoStack: [],
+        };
+
+        updatedTabs.push(pdfTab);
+
+        set({
+          tabs: updatedTabs,
+          activeTabIndex: updatedTabs.length - 1,
+          currentFile: pdfPath,
+          currentContent: "",
+          isDirty: false,
+        });
+      },
+
+      // 打开卡片流标签页
+      openCardFlowTab: () => {
+        const { tabs, activeTabIndex, currentContent, isDirty, undoStack, redoStack } = get();
+
+        // 检查是否已有 cardflow 标签页
+        const existingIndex = tabs.findIndex((tab) => tab.type === "cardflow");
+        if (existingIndex !== -1) {
+          get().switchTab(existingIndex);
+          return;
+        }
+
+        // 保存当前标签页状态
+        let updatedTabs = [...tabs];
+        if (activeTabIndex >= 0 && tabs[activeTabIndex]) {
+          updatedTabs[activeTabIndex] = {
+            ...updatedTabs[activeTabIndex],
+            content: currentContent,
+            isDirty,
+            undoStack,
+            redoStack,
+          };
+        }
+
+        // 创建卡片流标签页
+        const cardFlowTab: Tab = {
+          id: "__card_flow__",
+          type: "cardflow",
+          path: "",
+          name: "卡片视图",
+          content: "",
+          isDirty: false,
+          undoStack: [],
+          redoStack: [],
+        };
+
+        updatedTabs.push(cardFlowTab);
+
+        set({
+          tabs: updatedTabs,
+          activeTabIndex: updatedTabs.length - 1,
+          currentFile: null,
+          currentContent: "",
+          isDirty: false,
+          undoStack: [],
+          redoStack: [],
+          lastSavedContent: "",
+        });
+      },
+
+      // 打开网页标签页
+      openWebpageTab: (url: string, title?: string) => {
+        const { tabs, activeTabIndex, currentContent, isDirty, undoStack, redoStack, switchTab } = get();
+
+        // 如果已有相同 URL 的网页标签，直接切换过去，避免重复创建
+        if (url) {
+          const existingIndex = tabs.findIndex(
+            (t) => t.type === "webpage" && t.webpageUrl === url
+          );
+          if (existingIndex !== -1) {
+            // 在切换前仍然保存当前标签页状态
+            if (activeTabIndex >= 0 && tabs[activeTabIndex]) {
+              const updatedTabs = [...tabs];
+              updatedTabs[activeTabIndex] = {
+                ...updatedTabs[activeTabIndex],
+                content: currentContent,
+                isDirty,
+                undoStack,
+                redoStack,
+              };
+              set({ tabs: updatedTabs });
+            }
+            switchTab(existingIndex);
             return;
           }
         }
-      }
-      
-      await refreshFileTree();
-      await openFile(checkPath());
-      return;
-    }
-    
-    // 使用指定文件名
-    const newPath = `${vaultPath}${separator}${name}.md`;
-    try {
-      await createFile(newPath);
-      await refreshFileTree();
-      await openFile(newPath);
-    } catch (error) {
-      console.error("Create file failed:", error);
-    }
-  },
 
-  // 手动推入历史记录（AI 修改时使用）
-  pushHistory: (type: "user" | "ai", description?: string) => {
-    const { currentContent, undoStack } = get();
-    const entry: HistoryEntry = {
-      content: currentContent,
-      type,
-      timestamp: Date.now(),
-      description,
-    };
-    set({ 
-      undoStack: [...undoStack, entry],
-      redoStack: [], // 清空重做栈
-    });
-  },
+        // 生成唯一 ID
+        const tabId = `__webpage_${Date.now()}__`;
 
-  // Update content (marks as dirty)
-  updateContent: (content: string, source: "user" | "ai" = "user", description?: string) => {
-    const { currentContent, undoStack } = get();
-    const now = Date.now();
-    
-    // 如果内容没变，不做任何处理
-    if (content === currentContent) return;
-    
-    if (source === "ai") {
-      // AI 修改：总是创建新的撤销点
-      const entry: HistoryEntry = {
-        content: currentContent, // 保存修改前的内容
-        type: "ai",
-        timestamp: now,
-        description: description || "AI 修改",
-      };
-      set({ 
-        currentContent: content, 
-        isDirty: true,
-        undoStack: [...undoStack, entry],
-        redoStack: [],
-      });
-    } else {
-      // 用户编辑：合并短时间内的编辑
-      if (now - lastUserEditTime > USER_EDIT_DEBOUNCE || undoStack.length === 0) {
-        // 超过 debounce 时间，创建新撤销点
-        const entry: HistoryEntry = {
-          content: currentContent,
-          type: "user",
-          timestamp: now,
-        };
-        set({ 
-          currentContent: content, 
-          isDirty: true,
-          undoStack: [...undoStack, entry],
+        // 保存当前标签页状态
+        let updatedTabs = [...tabs];
+        if (activeTabIndex >= 0 && tabs[activeTabIndex]) {
+          updatedTabs[activeTabIndex] = {
+            ...updatedTabs[activeTabIndex],
+            content: currentContent,
+            isDirty,
+            undoStack,
+            redoStack,
+          };
+        }
+
+        // 尝试从 URL 提取域名作为默认标题
+        let defaultTitle = title || '新标签页';
+        if (!title && url) {
+          try {
+            const urlObj = new URL(url);
+            defaultTitle = urlObj.hostname;
+          } catch {
+            // 无效 URL，使用默认标题
+          }
+        }
+
+        // 创建网页标签页
+        const webpageTab: Tab = {
+          id: tabId,
+          type: "webpage",
+          path: "",
+          name: defaultTitle,
+          content: "",
+          isDirty: false,
+          undoStack: [],
           redoStack: [],
-        });
-      } else {
-        // 在 debounce 时间内，只更新内容不创建新撤销点
-        set({ currentContent: content, isDirty: true });
-      }
-      lastUserEditTime = now;
-    }
-  },
+          webpageUrl: url,
+          webpageTitle: defaultTitle,
+        };
 
-  // 撤销
-  undo: () => {
-    const { undoStack, currentContent, redoStack } = get();
-    if (undoStack.length === 0) return;
-    
-    const lastEntry = undoStack[undoStack.length - 1];
-    const newUndoStack = undoStack.slice(0, -1);
-    
-    // 将当前内容推入重做栈
-    const redoEntry: HistoryEntry = {
-      content: currentContent,
-      type: lastEntry.type,
-      timestamp: Date.now(),
-      description: lastEntry.description,
-    };
-    
-    set({
-      currentContent: lastEntry.content,
-      undoStack: newUndoStack,
-      redoStack: [...redoStack, redoEntry],
-      isDirty: true,
-    });
-    
-    // 显示撤销提示
-    if (lastEntry.type === "ai") {
-      console.log(`[Undo] 撤销 AI 修改: ${lastEntry.description || "未命名"}`);
-    }
-  },
+        updatedTabs.push(webpageTab);
 
-  // 重做
-  redo: () => {
-    const { redoStack, currentContent, undoStack } = get();
-    if (redoStack.length === 0) return;
-    
-    const lastEntry = redoStack[redoStack.length - 1];
-    const newRedoStack = redoStack.slice(0, -1);
-    
-    // 将当前内容推入撤销栈
-    const undoEntry: HistoryEntry = {
-      content: currentContent,
-      type: lastEntry.type,
-      timestamp: Date.now(),
-      description: lastEntry.description,
-    };
-    
-    set({
-      currentContent: lastEntry.content,
-      redoStack: newRedoStack,
-      undoStack: [...undoStack, undoEntry],
-      isDirty: true,
-    });
-  },
-
-  // 检查是否可以撤销/重做
-  canUndo: () => get().undoStack.length > 0,
-  canRedo: () => get().redoStack.length > 0,
-
-  // Save current file
-  save: async () => {
-    const { currentFile, currentContent, isDirty } = get();
-    if (!currentFile || !isDirty) return;
-
-    set({ isSaving: true });
-    try {
-      await saveFile(currentFile, currentContent);
-      set({ isDirty: false, isSaving: false, lastSavedContent: currentContent });
-    } catch (error) {
-      console.error("Failed to save file:", error);
-      set({ isSaving: false });
-    }
-  },
-
-  // Close current file (now closes current tab)
-  closeFile: () => {
-    const { activeTabIndex } = get();
-    if (activeTabIndex >= 0) {
-      get().closeTab(activeTabIndex);
-    }
-  },
-
-  // Navigation: Go back
-  goBack: () => {
-    const { navigationHistory, navigationIndex } = get();
-    if (navigationIndex > 0) {
-      const newIndex = navigationIndex - 1;
-      const path = navigationHistory[newIndex];
-      set({ navigationIndex: newIndex });
-      get().openFile(path, false); // 不添加到历史
-    }
-  },
-
-  // Navigation: Go forward
-  goForward: () => {
-    const { navigationHistory, navigationIndex } = get();
-    if (navigationIndex < navigationHistory.length - 1) {
-      const newIndex = navigationIndex + 1;
-      const path = navigationHistory[newIndex];
-      set({ navigationIndex: newIndex });
-      get().openFile(path, false); // 不添加到历史
-    }
-  },
-
-  // Check if can go back/forward
-  canGoBack: () => get().navigationIndex > 0,
-  canGoForward: () => {
-    const { navigationHistory, navigationIndex } = get();
-    return navigationIndex < navigationHistory.length - 1;
-  },
-  
-  // Clear vault and reset to welcome screen
-  clearVault: () => {
-    set({
-      vaultPath: null,
-      fileTree: [],
-      tabs: [],
-      activeTabIndex: -1,
-      currentFile: null,
-      currentContent: "",
-      isDirty: false,
-      undoStack: [],
-      redoStack: [],
-      navigationHistory: [],
-      navigationIndex: -1,
-    });
-  },
-  
-  // Reload file if it's currently open (for external updates like database edits)
-  reloadFileIfOpen: async (path: string) => {
-    const { tabs, activeTabIndex, currentFile } = get();
-    
-    // 查找该文件是否在标签页中打开
-    const tabIndex = tabs.findIndex(t => t.type === 'file' && t.path === path);
-    if (tabIndex === -1) return;
-    
-    try {
-      const newContent = await readFile(path);
-      const updatedTabs = tabs.map((tab, i) => 
-        i === tabIndex ? { ...tab, content: newContent, isDirty: false } : tab
-      );
-      
-      // 如果是当前激活的标签页，同时更新 currentContent
-      if (tabIndex === activeTabIndex && currentFile === path) {
         set({
           tabs: updatedTabs,
-          currentContent: newContent,
-          lastSavedContent: newContent,
+          activeTabIndex: updatedTabs.length - 1,
+          currentFile: null,
+          currentContent: "",
           isDirty: false,
         });
-      } else {
+      },
+
+      // 更新网页标签页信息
+      updateWebpageTab: (tabId: string, url?: string, title?: string) => {
+        const { tabs } = get();
+
+        const updatedTabs = tabs.map(tab => {
+          if (tab.id === tabId && tab.type === 'webpage') {
+            return {
+              ...tab,
+              webpageUrl: url ?? tab.webpageUrl,
+              webpageTitle: title ?? tab.webpageTitle,
+              name: title ?? tab.name,
+            };
+          }
+          return tab;
+        });
+
         set({ tabs: updatedTabs });
-      }
-    } catch (error) {
-      console.error(`Failed to reload file ${path}:`, error);
-    }
-  },
-}),
+      },
+
+      // 打开闪卡标签页
+      openFlashcardTab: (deckId?: string) => {
+        const { tabs, activeTabIndex, currentContent, isDirty, undoStack, redoStack, switchTab } = get();
+
+        // 如果已有闪卡标签页，直接切换
+        const existingIndex = tabs.findIndex(t => t.type === "flashcard");
+        if (existingIndex !== -1) {
+          if (activeTabIndex >= 0 && tabs[activeTabIndex]) {
+            const updatedTabs = [...tabs];
+            updatedTabs[activeTabIndex] = {
+              ...updatedTabs[activeTabIndex],
+              content: currentContent,
+              isDirty,
+              undoStack,
+              redoStack,
+            };
+            // 更新牌组 ID
+            updatedTabs[existingIndex] = {
+              ...updatedTabs[existingIndex],
+              flashcardDeckId: deckId,
+            };
+            set({ tabs: updatedTabs });
+          }
+          switchTab(existingIndex);
+          return;
+        }
+
+        // 生成唯一 ID
+        const tabId = `__flashcard_${Date.now()}__`;
+
+        // 保存当前标签页状态
+        let updatedTabs = [...tabs];
+        if (activeTabIndex >= 0 && tabs[activeTabIndex]) {
+          updatedTabs[activeTabIndex] = {
+            ...updatedTabs[activeTabIndex],
+            content: currentContent,
+            isDirty,
+            undoStack,
+            redoStack,
+          };
+        }
+
+        // 创建闪卡标签页
+        const flashcardTab: Tab = {
+          id: tabId,
+          type: "flashcard",
+          path: "",
+          name: "闪卡复习",
+          content: "",
+          isDirty: false,
+          undoStack: [],
+          redoStack: [],
+          flashcardDeckId: deckId,
+        };
+
+        updatedTabs.push(flashcardTab);
+
+        set({
+          tabs: updatedTabs,
+          activeTabIndex: updatedTabs.length - 1,
+          currentFile: null,
+          currentContent: "",
+          isDirty: false,
+        });
+      },
+
+      // 创建新文件
+      createNewFile: async (fileName?: string) => {
+        const { vaultPath, refreshFileTree, openFile } = get();
+        if (!vaultPath) return;
+
+        const separator = vaultPath.includes("\\") ? "\\" : "/";
+
+        // 生成文件名
+        let name = fileName;
+        if (!name) {
+          // 生成默认文件名：未命名、未命名 1、未命名 2...
+          const baseName = "未命名";
+          let counter = 0;
+          let finalName = baseName;
+
+          // 检查文件是否存在
+          const checkPath = () => `${vaultPath}${separator}${finalName}.md`;
+
+          // 简单检查 - 尝试创建，如果失败则增加计数器
+          while (true) {
+            try {
+              await createFile(checkPath());
+              break;
+            } catch {
+              counter++;
+              finalName = `${baseName} ${counter}`;
+              if (counter > 100) {
+                console.error("Too many untitled files");
+                return;
+              }
+            }
+          }
+
+          await refreshFileTree();
+          await openFile(checkPath());
+          return;
+        }
+
+        // 使用指定文件名
+        const newPath = `${vaultPath}${separator}${name}.md`;
+        try {
+          await createFile(newPath);
+          await refreshFileTree();
+          await openFile(newPath);
+        } catch (error) {
+          console.error("Create file failed:", error);
+        }
+      },
+
+      // 手动推入历史记录（AI 修改时使用）
+      pushHistory: (type: "user" | "ai", description?: string) => {
+        const { currentContent, undoStack } = get();
+        const entry: HistoryEntry = {
+          content: currentContent,
+          type,
+          timestamp: Date.now(),
+          description,
+        };
+        const newUndoStack = trimUndoStack([...undoStack, entry]);
+        set({
+          undoStack: newUndoStack,
+          redoStack: [], // 清空重做栈
+        });
+      },
+
+      // Update content (marks as dirty)
+      updateContent: (content: string, source: "user" | "ai" = "user", description?: string) => {
+        const { currentContent, undoStack } = get();
+        const now = Date.now();
+
+        // 如果内容没变，不做任何处理
+        if (content === currentContent) return;
+
+        if (source === "ai") {
+          // AI 修改：总是创建新的撤销点
+          const entry: HistoryEntry = {
+            content: currentContent, // 保存修改前的内容
+            type: "ai",
+            timestamp: now,
+            description: description || "AI 修改",
+          };
+          const newUndoStack = trimUndoStack([...undoStack, entry]);
+          set({
+            currentContent: content,
+            isDirty: true,
+            undoStack: newUndoStack,
+            redoStack: [],
+          });
+        } else {
+          // 用户编辑：合并短时间内的编辑
+          if (now - lastUserEditTime > USER_EDIT_DEBOUNCE || undoStack.length === 0) {
+            // 超过 debounce 时间，创建新撤销点
+            const entry: HistoryEntry = {
+              content: currentContent,
+              type: "user",
+              timestamp: now,
+            };
+            const newUndoStack = trimUndoStack([...undoStack, entry]);
+            set({
+              currentContent: content,
+              isDirty: true,
+              undoStack: newUndoStack,
+              redoStack: [],
+            });
+          } else {
+            // 在 debounce 时间内，只更新内容不创建新撤销点
+            set({ currentContent: content, isDirty: true });
+          }
+          lastUserEditTime = now;
+        }
+      },
+
+      // 撤销
+      undo: () => {
+        const { undoStack, currentContent, redoStack } = get();
+        if (undoStack.length === 0) return;
+
+        const lastEntry = undoStack[undoStack.length - 1];
+        const newUndoStack = undoStack.slice(0, -1);
+
+        // 将当前内容推入重做栈
+        const redoEntry: HistoryEntry = {
+          content: currentContent,
+          type: lastEntry.type,
+          timestamp: Date.now(),
+          description: lastEntry.description,
+        };
+
+        set({
+          currentContent: lastEntry.content,
+          undoStack: newUndoStack,
+          redoStack: [...redoStack, redoEntry],
+          isDirty: true,
+        });
+
+        // 显示撤销提示
+        if (lastEntry.type === "ai") {
+          console.log(`[Undo] 撤销 AI 修改: ${lastEntry.description || "未命名"}`);
+        }
+      },
+
+      // 重做
+      redo: () => {
+        const { redoStack, currentContent, undoStack } = get();
+        if (redoStack.length === 0) return;
+
+        const lastEntry = redoStack[redoStack.length - 1];
+        const newRedoStack = redoStack.slice(0, -1);
+
+        // 将当前内容推入撤销栈
+        const undoEntry: HistoryEntry = {
+          content: currentContent,
+          type: lastEntry.type,
+          timestamp: Date.now(),
+          description: lastEntry.description,
+        };
+
+        set({
+          currentContent: lastEntry.content,
+          redoStack: newRedoStack,
+          undoStack: [...undoStack, undoEntry],
+          isDirty: true,
+        });
+      },
+
+      // 检查是否可以撤销/重做
+      canUndo: () => get().undoStack.length > 0,
+      canRedo: () => get().redoStack.length > 0,
+
+      // Save current file
+      save: async () => {
+        const { currentFile, currentContent, isDirty } = get();
+        if (!currentFile || !isDirty) return;
+
+        set({ isSaving: true });
+        try {
+          await saveFile(currentFile, currentContent);
+          set({ isDirty: false, isSaving: false, lastSavedContent: currentContent });
+        } catch (error) {
+          console.error("Failed to save file:", error);
+          set({ isSaving: false });
+        }
+      },
+
+      // Close current file (now closes current tab)
+      closeFile: () => {
+        const { activeTabIndex } = get();
+        if (activeTabIndex >= 0) {
+          get().closeTab(activeTabIndex);
+        }
+      },
+
+      // Navigation: Go back
+      goBack: () => {
+        const { navigationHistory, navigationIndex } = get();
+        if (navigationIndex > 0) {
+          const newIndex = navigationIndex - 1;
+          const path = navigationHistory[newIndex];
+          set({ navigationIndex: newIndex });
+          get().openFile(path, false); // 不添加到历史
+        }
+      },
+
+      // Navigation: Go forward
+      goForward: () => {
+        const { navigationHistory, navigationIndex } = get();
+        if (navigationIndex < navigationHistory.length - 1) {
+          const newIndex = navigationIndex + 1;
+          const path = navigationHistory[newIndex];
+          set({ navigationIndex: newIndex });
+          get().openFile(path, false); // 不添加到历史
+        }
+      },
+
+      // Check if can go back/forward
+      canGoBack: () => get().navigationIndex > 0,
+      canGoForward: () => {
+        const { navigationHistory, navigationIndex } = get();
+        return navigationIndex < navigationHistory.length - 1;
+      },
+
+      // Clear vault and reset to welcome screen
+      clearVault: () => {
+        set({
+          vaultPath: null,
+          fileTree: [],
+          tabs: [],
+          activeTabIndex: -1,
+          currentFile: null,
+          currentContent: "",
+          isDirty: false,
+          undoStack: [],
+          redoStack: [],
+          navigationHistory: [],
+          navigationIndex: -1,
+        });
+      },
+
+      // Reload file if it's currently open (for external updates like database edits)
+      reloadFileIfOpen: async (path: string) => {
+        const { tabs, activeTabIndex, currentFile } = get();
+
+        // 查找该文件是否在标签页中打开
+        const tabIndex = tabs.findIndex(t => t.type === 'file' && t.path === path);
+        if (tabIndex === -1) return;
+
+        try {
+          const newContent = await readFile(path);
+          const updatedTabs = tabs.map((tab, i) =>
+            i === tabIndex ? { ...tab, content: newContent, isDirty: false } : tab
+          );
+
+          // 如果是当前激活的标签页，同时更新 currentContent
+          if (tabIndex === activeTabIndex && currentFile === path) {
+            set({
+              tabs: updatedTabs,
+              currentContent: newContent,
+              lastSavedContent: newContent,
+              isDirty: false,
+            });
+          } else {
+            set({ tabs: updatedTabs });
+          }
+        } catch (error) {
+          console.error(`Failed to reload file ${path}:`, error);
+        }
+      },
+    }),
     {
       name: "lumina-workspace",
       partialize: (state) => ({


### PR DESCRIPTION
修复了mac版工作区笔记过多导致白屏的问题
<img width="1269" height="902" alt="image" src="https://github.com/user-attachments/assets/c30d3feb-d5e9-49bc-8cef-a8a92100223c" />

# Bug 修复报告：编辑器白屏问题

**修复日期**: 2026-01-03  
**修复分支**: `fix/white-screen-webkit-compat`  
**严重程度**: 🔴 严重 (Critical)  
**状态**: ✅ 已修复

---

## 问题描述

### 现象
用户在 Lumina-Note Mac 版中打开 5-7 个笔记后，应用出现**白屏卡死**，界面完全无响应，无法恢复。

### 复现步骤
1. 启动 Lumina-Note Mac 版
2. 依次打开 5-7 个 Markdown 笔记文件
3. 在笔记之间切换或编辑
4. 应用变为白屏，无法操作

### 影响范围
- **平台**: macOS (Tauri WebKit WebView)
- **触发条件**: 打开多个笔记文件
- **用户影响**: 应用完全不可用，需要强制退出

---

## 根因分析

### 核心问题：`requestIdleCallback` API 不兼容

通过开发者工具 Console 发现关键错误：

```
ReferenceError: Can't find variable: requestIdleCallback
```

**原因**: `requestIdleCallback` 是 Chrome/Firefox 支持的浏览器 API，但 **macOS WebKit (Safari 引擎) 不支持此 API**。

错误发生在 [CodeMirrorEditor.tsx](file:///Users/sawyerlau/Project/Lumina-Note/src/editor/CodeMirrorEditor.tsx) 的 KaTeX 公式预渲染逻辑中：

```typescript
// 修复前的代码 (会崩溃)
requestIdleCallback?.(() => {
  // 预渲染公式...
}, { timeout: 100 }) || setTimeout(() => {
  // 备用逻辑...
}, 16);
```

虽然使用了可选链 `?.`，但整个表达式在 `requestIdleCallback` 未定义时仍会触发执行流程，导致 JavaScript 运行时错误。

### 次要问题 (预防性修复)

在调查过程中还发现以下性能隐患：

| 问题 | 位置 | 影响 |
|-----|------|-----|
| `undoStack` 无限增长 | [useFileStore.ts](file:///Users/sawyerlau/Project/Lumina-Note/src/stores/useFileStore.ts) | 内存泄漏 |
| [LocalGraph](file:///Users/sawyerlau/Project/Lumina-Note/src/components/effects/LocalGraph.tsx#27-485) 每次打字都扫描磁盘 | [LocalGraph.tsx](file:///Users/sawyerlau/Project/Lumina-Note/src/components/effects/LocalGraph.tsx) | 主线程阻塞 |
| `katexCache` 无大小限制 | [CodeMirrorEditor.tsx](file:///Users/sawyerlau/Project/Lumina-Note/src/editor/CodeMirrorEditor.tsx) | 内存泄漏 |

---

## 修复方案

### 1. 核心修复：`requestIdleCallback` 兼容性

**文件**: [src/editor/CodeMirrorEditor.tsx](file:///Users/sawyerlau/Project/Lumina-Note/src/editor/CodeMirrorEditor.tsx)

```diff
+// 安全的 requestIdleCallback polyfill
+const safeRequestIdleCallback = 
+  typeof window !== 'undefined' && 'requestIdleCallback' in window
+    ? window.requestIdleCallback
+    : (cb: () => void) => setTimeout(cb, 16);

 function schedulePrerenderBatch() {
   if (prerenderScheduled || prerenderQueue.length === 0) return;
   prerenderScheduled = true;
   
-  requestIdleCallback?.(() => {
+  safeRequestIdleCallback(() => {
     const batch = prerenderQueue.splice(0, 5);
     batch.forEach(({ formula, displayMode }) => prerenderMath(formula, displayMode));
     prerenderScheduled = false;
     if (prerenderQueue.length > 0) schedulePrerenderBatch();
-  }, { timeout: 100 }) || setTimeout(() => { ... }, 16);
+  }, { timeout: 100 });
 }
```

### 2. 预防性修复：限制 undoStack 大小

**文件**: [src/stores/useFileStore.ts](file:///Users/sawyerlau/Project/Lumina-Note/src/stores/useFileStore.ts)

```diff
+const MAX_UNDO_HISTORY = 50;
+
+function trimUndoStack(stack: HistoryEntry[]): HistoryEntry[] {
+  if (stack.length <= MAX_UNDO_HISTORY) return stack;
+  return stack.slice(stack.length - MAX_UNDO_HISTORY);
+}
```

### 3. 预防性修复：优化 LocalGraph 性能

**文件**: [src/components/effects/LocalGraph.tsx](file:///Users/sawyerlau/Project/Lumina-Note/src/components/effects/LocalGraph.tsx)

- 添加反向链接缓存
- 只有切换文件时才扫描磁盘
- 内容变化时使用 300ms 防抖

### 4. 预防性修复：限制 katexCache 大小

**文件**: [src/editor/CodeMirrorEditor.tsx](file:///Users/sawyerlau/Project/Lumina-Note/src/editor/CodeMirrorEditor.tsx)

```diff
+const MAX_KATEX_CACHE = 500;
+
 function prerenderMath(formula: string, displayMode: boolean): void {
   const key = `${formula}|${displayMode}`;
   if (katexCache.has(key)) return;
   
+  if (katexCache.size >= MAX_KATEX_CACHE) {
+    const keysToDelete = Array.from(katexCache.keys()).slice(0, 100);
+    keysToDelete.forEach(k => katexCache.delete(k));
+  }
```

### 5. 清理：抑制 Rust 编译警告

**文件**: [src-tauri/src/main.rs](file:///Users/sawyerlau/Project/Lumina-Note/src-tauri/src/main.rs), [src-tauri/src/lib.rs](file:///Users/sawyerlau/Project/Lumina-Note/src-tauri/src/lib.rs)

```diff
+#![allow(dead_code)]
```

**效果**: 编译警告从 135 个减少到 0 个

---

## 修改文件清单

| 文件 | 修改类型 | 描述 |
|-----|---------|-----|
| [src/editor/CodeMirrorEditor.tsx](file:///Users/sawyerlau/Project/Lumina-Note/src/editor/CodeMirrorEditor.tsx) | 🔴 BugFix | 修复 requestIdleCallback 兼容性 |
| [src/stores/useFileStore.ts](file:///Users/sawyerlau/Project/Lumina-Note/src/stores/useFileStore.ts) | 🟡 Optimize | 限制 undoStack 大小为 50 |
| [src/components/effects/LocalGraph.tsx](file:///Users/sawyerlau/Project/Lumina-Note/src/components/effects/LocalGraph.tsx) | 🟡 Optimize | 添加缓存和防抖 |
| [src/components/effects/KnowledgeGraph.tsx](file:///Users/sawyerlau/Project/Lumina-Note/src/components/effects/KnowledgeGraph.tsx) | 🟡 Optimize | 添加并发限制 |
| [src-tauri/src/main.rs](file:///Users/sawyerlau/Project/Lumina-Note/src-tauri/src/main.rs) | 🟢 Cleanup | 抑制 dead_code 警告 |
| [src-tauri/src/lib.rs](file:///Users/sawyerlau/Project/Lumina-Note/src-tauri/src/lib.rs) | 🟢 Cleanup | 抑制 dead_code 警告 |
| [src-tauri/src/langgraph/ablation.rs](file:///Users/sawyerlau/Project/Lumina-Note/src-tauri/src/langgraph/ablation.rs) | 🟢 Cleanup | 抑制 dead_code 警告 |
| [src-tauri/src/agent/debug_log.rs](file:///Users/sawyerlau/Project/Lumina-Note/src-tauri/src/agent/debug_log.rs) | 🟢 Cleanup | 抑制 dead_code 警告 |

---

## 验证结果

### 功能测试
- [x] 打开 10+ 个笔记文件，无白屏
- [x] 在笔记之间快速切换，响应正常
- [x] 编辑笔记内容，无卡顿
- [x] 撤销/重做功能正常

### 单元测试
```
Test Files  1 passed (1)
Tests  5 passed (5) ✅
```

### 编译检查
```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.16s
Warnings: 0
```

---

## 经验总结

1. **跨平台 API 兼容性**: Tauri 在 macOS 使用 WebKit 引擎，与 Chrome/Electron 环境有 API 差异，需要特别注意 polyfill。

2. **防御性编程**: 全局缓存（如 `katexCache`、`undoStack`）需要设置大小上限，防止内存泄漏。

3. **性能敏感操作**: 磁盘扫描等耗时操作不应在每次状态变化时执行，需要使用防抖和缓存。

4. **开发者工具的重要性**: Console 错误信息是定位问题的关键。

---