### PR TITLE
Add local favorites for markdown notes

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -46,6 +46,18 @@ export default {
     toggleSidebar: 'Toggle Sidebar',
     toggleAIPanel: 'Toggle AI Panel',
   },
+
+  favorites: {
+    title: 'Favorites',
+    add: 'Add to favorites',
+    remove: 'Remove favorite',
+    empty: 'No favorites yet',
+    sortManual: 'Manual',
+    sortRecentAdded: 'Recently added',
+    sortRecentOpened: 'Recently opened',
+    moveUp: 'Move up',
+    moveDown: 'Move down',
+  },
   
   // Editor
   editor: {

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -46,6 +46,18 @@ export default {
     toggleSidebar: 'サイドバーを切替',
     toggleAIPanel: 'AI パネルを切替',
   },
+
+  favorites: {
+    title: 'お気に入り',
+    add: 'お気に入りに追加',
+    remove: 'お気に入りから削除',
+    empty: 'お気に入りなし',
+    sortManual: '手動',
+    sortRecentAdded: '最近追加',
+    sortRecentOpened: '最近開いた',
+    moveUp: '上へ',
+    moveDown: '下へ',
+  },
   
   // エディター
   editor: {

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -46,6 +46,18 @@ export default {
     toggleSidebar: '切换侧边栏',
     toggleAIPanel: '切换 AI 面板',
   },
+
+  favorites: {
+    title: '收藏夹',
+    add: '加入收藏',
+    remove: '取消收藏',
+    empty: '暂无收藏',
+    sortManual: '手动',
+    sortRecentAdded: '最近收藏',
+    sortRecentOpened: '最近打开',
+    moveUp: '上移',
+    moveDown: '下移',
+  },
   
   // 编辑器
   editor: {

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -46,6 +46,18 @@ export default {
     toggleSidebar: '切換側邊欄',
     toggleAIPanel: '切換 AI 面板',
   },
+
+  favorites: {
+    title: '收藏夾',
+    add: '加入收藏',
+    remove: '取消收藏',
+    empty: '暫無收藏',
+    sortManual: '手動',
+    sortRecentAdded: '最近收藏',
+    sortRecentOpened: '最近打開',
+    moveUp: '上移',
+    moveDown: '下移',
+  },
   
   // 編輯器
   editor: {

--- a/src/stores/useFavoriteStore.test.ts
+++ b/src/stores/useFavoriteStore.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { useFavoriteStore } from "./useFavoriteStore";
+import type { FileEntry } from "@/lib/tauri";
+
+const makeFileTree = (paths: string[]): FileEntry[] => {
+  const toEntry = (path: string): FileEntry => ({
+    name: path.split(/[/\\]/).pop() || path,
+    path,
+    is_dir: false,
+    children: null,
+  });
+  return paths.map(toEntry);
+};
+
+describe("useFavoriteStore", () => {
+  beforeEach(() => {
+    useFavoriteStore.setState({
+      favorites: {},
+      manualOrder: [],
+      defaultSortMode: "manual",
+    });
+    vi.useRealTimers();
+  });
+
+  it("adds only markdown favorites", () => {
+    const store = useFavoriteStore.getState();
+    store.addFavorite("/notes/a.md");
+    store.addFavorite("/notes/b.pdf");
+
+    expect(store.isFavorite("/notes/a.md")).toBe(true);
+    expect(store.isFavorite("/notes/b.pdf")).toBe(false);
+    expect(store.getFavorites("manual").map((f) => f.path)).toEqual(["/notes/a.md"]);
+  });
+
+  it("supports manual ordering and move", () => {
+    const store = useFavoriteStore.getState();
+    store.addFavorite("/notes/a.md");
+    store.addFavorite("/notes/b.md");
+    store.addFavorite("/notes/c.md");
+
+    store.moveFavorite(2, 0);
+    const ordered = store.getFavorites("manual").map((f) => f.path);
+    expect(ordered).toEqual(["/notes/c.md", "/notes/a.md", "/notes/b.md"]);
+  });
+
+  it("sorts by recent added", () => {
+    const store = useFavoriteStore.getState();
+    store.addFavorite("/notes/a.md", 1000);
+    store.addFavorite("/notes/b.md", 2000);
+    store.addFavorite("/notes/c.md", 1500);
+
+    const ordered = store.getFavorites("recentAdded").map((f) => f.path);
+    expect(ordered).toEqual(["/notes/b.md", "/notes/c.md", "/notes/a.md"]);
+  });
+
+  it("sorts by recent opened with addedAt fallback", () => {
+    const store = useFavoriteStore.getState();
+    store.addFavorite("/notes/a.md", 1000);
+    store.addFavorite("/notes/b.md", 2000);
+    store.addFavorite("/notes/c.md", 1500);
+
+    store.markOpened("/notes/a.md", 5000);
+    store.markOpened("/notes/c.md", 3000);
+
+    const ordered = store.getFavorites("recentOpened").map((f) => f.path);
+    expect(ordered).toEqual(["/notes/a.md", "/notes/c.md", "/notes/b.md"]);
+  });
+
+  it("updates paths on rename", () => {
+    const store = useFavoriteStore.getState();
+    store.addFavorite("/notes/a.md");
+    store.updatePath("/notes/a.md", "/notes/renamed.md");
+
+    expect(store.isFavorite("/notes/a.md")).toBe(false);
+    expect(store.isFavorite("/notes/renamed.md")).toBe(true);
+    expect(store.getFavorites("manual").map((f) => f.path)).toEqual(["/notes/renamed.md"]);
+  });
+
+  it("updates paths on folder move", () => {
+    const store = useFavoriteStore.getState();
+    store.addFavorite("/notes/folder/a.md");
+    store.addFavorite("/notes/folder/sub/b.md");
+
+    store.updatePathsForFolderMove("/notes/folder", "/notes/moved");
+    const ordered = store.getFavorites("manual").map((f) => f.path);
+    expect(ordered).toEqual(["/notes/moved/a.md", "/notes/moved/sub/b.md"]);
+  });
+
+  it("prunes missing favorites based on file tree", () => {
+    const store = useFavoriteStore.getState();
+    store.addFavorite("/notes/a.md");
+    store.addFavorite("/notes/b.md");
+    store.addFavorite("/notes/c.md");
+
+    const tree = makeFileTree(["/notes/a.md", "/notes/c.md"]);
+    store.pruneMissing(tree);
+
+    const remaining = store.getFavorites("manual").map((f) => f.path);
+    expect(remaining).toEqual(["/notes/a.md", "/notes/c.md"]);
+  });
+});

--- a/src/stores/useFavoriteStore.ts
+++ b/src/stores/useFavoriteStore.ts
@@ -1,0 +1,239 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import type { FileEntry } from "@/lib/tauri";
+
+export type FavoriteSortMode = "manual" | "recentAdded" | "recentOpened";
+
+export interface FavoriteEntry {
+  path: string;
+  addedAt: number;
+  lastOpenedAt: number | null;
+}
+
+interface FavoriteState {
+  favorites: Record<string, FavoriteEntry>;
+  manualOrder: string[];
+  defaultSortMode: FavoriteSortMode;
+
+  addFavorite: (path: string, addedAt?: number) => void;
+  removeFavorite: (path: string) => void;
+  toggleFavorite: (path: string) => void;
+  isFavorite: (path: string) => boolean;
+  markOpened: (path: string, openedAt?: number) => void;
+  updatePath: (oldPath: string, newPath: string) => void;
+  updatePathsForFolderMove: (oldFolder: string, newFolder: string) => void;
+  moveFavorite: (fromIndex: number, toIndex: number) => void;
+  setManualOrder: (paths: string[]) => void;
+  setDefaultSortMode: (mode: FavoriteSortMode) => void;
+  getFavorites: (mode?: FavoriteSortMode) => FavoriteEntry[];
+  pruneMissing: (fileTree: FileEntry[]) => void;
+}
+
+const isMarkdownPath = (path: string) => path.toLowerCase().endsWith(".md");
+
+const flattenMarkdownPaths = (entries: FileEntry[]): Set<string> => {
+  const paths = new Set<string>();
+  const walk = (nodes: FileEntry[]) => {
+    for (const node of nodes) {
+      if (node.is_dir && node.children) {
+        walk(node.children);
+      } else if (!node.is_dir && isMarkdownPath(node.path)) {
+        paths.add(node.path);
+      }
+    }
+  };
+  walk(entries);
+  return paths;
+};
+
+const sortByRecentAdded = (entries: FavoriteEntry[]) =>
+  [...entries].sort((a, b) => b.addedAt - a.addedAt);
+
+const sortByRecentOpened = (entries: FavoriteEntry[]) =>
+  [...entries].sort((a, b) => {
+    const aOpened = a.lastOpenedAt ?? 0;
+    const bOpened = b.lastOpenedAt ?? 0;
+    if (aOpened !== bOpened) return bOpened - aOpened;
+    return b.addedAt - a.addedAt;
+  });
+
+export const useFavoriteStore = create<FavoriteState>()(
+  persist(
+    (set, get) => ({
+      favorites: {},
+      manualOrder: [],
+      defaultSortMode: "manual",
+
+      addFavorite: (path, addedAt = Date.now()) => {
+        if (!isMarkdownPath(path)) return;
+        set((state) => {
+          if (state.favorites[path]) return state;
+          const entry: FavoriteEntry = {
+            path,
+            addedAt,
+            lastOpenedAt: null,
+          };
+          return {
+            favorites: { ...state.favorites, [path]: entry },
+            manualOrder: [...state.manualOrder, path],
+          };
+        });
+      },
+
+      removeFavorite: (path) => {
+        set((state) => {
+          if (!state.favorites[path]) return state;
+          const { [path]: _removed, ...rest } = state.favorites;
+          return {
+            favorites: rest,
+            manualOrder: state.manualOrder.filter((p) => p !== path),
+          };
+        });
+      },
+
+      toggleFavorite: (path) => {
+        if (get().favorites[path]) {
+          get().removeFavorite(path);
+        } else {
+          get().addFavorite(path);
+        }
+      },
+
+      isFavorite: (path) => Boolean(get().favorites[path]),
+
+      markOpened: (path, openedAt = Date.now()) => {
+        if (!get().favorites[path]) return;
+        set((state) => ({
+          favorites: {
+            ...state.favorites,
+            [path]: {
+              ...state.favorites[path],
+              lastOpenedAt: openedAt,
+            },
+          },
+        }));
+      },
+
+      updatePath: (oldPath, newPath) => {
+        if (!get().favorites[oldPath]) return;
+        if (!isMarkdownPath(newPath)) {
+          get().removeFavorite(oldPath);
+          return;
+        }
+        set((state) => {
+          const entry = state.favorites[oldPath];
+          const { [oldPath]: _removed, ...rest } = state.favorites;
+          return {
+            favorites: {
+              ...rest,
+              [newPath]: { ...entry, path: newPath },
+            },
+            manualOrder: state.manualOrder.map((p) => (p === oldPath ? newPath : p)),
+          };
+        });
+      },
+
+      updatePathsForFolderMove: (oldFolder, newFolder) => {
+        const normalize = (p: string) => p.replace(/\\/g, "/");
+        const oldPrefix = normalize(oldFolder);
+        const newPrefix = normalize(newFolder);
+        set((state) => {
+          let changed = false;
+          const nextFavorites: Record<string, FavoriteEntry> = {};
+          const nextOrder: string[] = [];
+
+          for (const path of state.manualOrder) {
+            const normalizedPath = normalize(path);
+            if (normalizedPath === oldPrefix || normalizedPath.startsWith(oldPrefix + "/")) {
+              const relativePath = normalizedPath.slice(oldPrefix.length);
+              const nextPath = newPrefix + relativePath;
+              const entry = state.favorites[path];
+              if (entry) {
+                nextFavorites[nextPath] = { ...entry, path: nextPath };
+                nextOrder.push(nextPath);
+                changed = true;
+              }
+            } else if (state.favorites[path]) {
+              nextFavorites[path] = state.favorites[path];
+              nextOrder.push(path);
+            }
+          }
+
+          if (!changed) return state;
+          return { favorites: nextFavorites, manualOrder: nextOrder };
+        });
+      },
+
+      moveFavorite: (fromIndex, toIndex) => {
+        set((state) => {
+          if (fromIndex === toIndex) return state;
+          if (fromIndex < 0 || toIndex < 0) return state;
+          if (fromIndex >= state.manualOrder.length || toIndex >= state.manualOrder.length) {
+            return state;
+          }
+          const next = [...state.manualOrder];
+          const [moved] = next.splice(fromIndex, 1);
+          next.splice(toIndex, 0, moved);
+          return { manualOrder: next };
+        });
+      },
+
+      setManualOrder: (paths) => {
+        set((state) => ({
+          manualOrder: paths.filter((p) => Boolean(state.favorites[p])),
+        }));
+      },
+
+      setDefaultSortMode: (mode) => set({ defaultSortMode: mode }),
+
+      getFavorites: (mode) => {
+        const { favorites, manualOrder, defaultSortMode } = get();
+        const entries = Object.values(favorites);
+        const sortMode = mode ?? defaultSortMode;
+        if (sortMode === "recentAdded") return sortByRecentAdded(entries);
+        if (sortMode === "recentOpened") return sortByRecentOpened(entries);
+        const orderIndex = new Map(manualOrder.map((p, i) => [p, i]));
+        return [...entries].sort((a, b) => {
+          const aIndex = orderIndex.get(a.path);
+          const bIndex = orderIndex.get(b.path);
+          if (aIndex === undefined && bIndex === undefined) return 0;
+          if (aIndex === undefined) return 1;
+          if (bIndex === undefined) return -1;
+          return aIndex - bIndex;
+        });
+      },
+
+      pruneMissing: (fileTree) => {
+        const validPaths = flattenMarkdownPaths(fileTree);
+        set((state) => {
+          const nextFavorites: Record<string, FavoriteEntry> = {};
+          const nextOrder: string[] = [];
+          for (const path of state.manualOrder) {
+            if (validPaths.has(path) && state.favorites[path]) {
+              nextFavorites[path] = state.favorites[path];
+              nextOrder.push(path);
+            }
+          }
+          for (const entry of Object.values(state.favorites)) {
+            if (validPaths.has(entry.path) && !nextFavorites[entry.path]) {
+              nextFavorites[entry.path] = entry;
+              nextOrder.push(entry.path);
+            }
+          }
+          return {
+            favorites: nextFavorites,
+            manualOrder: nextOrder,
+          };
+        });
+      },
+    }),
+    {
+      name: "lumina-favorites",
+      partialize: (state) => ({
+        favorites: state.favorites,
+        manualOrder: state.manualOrder,
+        defaultSortMode: state.defaultSortMode,
+      }),
+    }
+  )
+);

--- a/src/stores/useSplitStore.ts
+++ b/src/stores/useSplitStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { readFile, saveFile } from "@/lib/tauri";
 import { parseFrontmatter } from "@/services/markdown/frontmatter";
+import { useFavoriteStore } from "@/stores/useFavoriteStore";
 
 // 分栏文件类型
 export type SplitFileType = 'markdown' | 'pdf';
@@ -58,6 +59,7 @@ export const useSplitStore = create<SplitState>((set, get) => ({
         secondaryIsDirty: false,
         isLoadingSecondary: false,
       });
+      useFavoriteStore.getState().markOpened(path);
     } catch (error) {
       console.error("Failed to open secondary file:", error);
       set({ isLoadingSecondary: false });


### PR DESCRIPTION
## Summary\n- add local favorites store with sorting, path updates, and pruning\n- surface favorites in the sidebar with sorting and manual reordering\n- sync favorites on open/rename/move and add i18n labels\n\n## Testing\n- npm run test:run -- src/stores/useFavoriteStore.test.ts src/stores/useSplitStore.test.ts