### PR TITLE
feat(pdf): send selected text from popover to AI modes

### DIFF
--- a/src/components/layout/MainAIChatShell.tsx
+++ b/src/components/layout/MainAIChatShell.tsx
@@ -229,6 +229,8 @@ export function MainAIChatShell() {
     checkFirstLoad: checkChatFirstLoad,
     config,
     totalTokensUsed: chatTotalTokens,
+    pendingInputAppends,
+    consumeInputAppends,
   } = useAIStore(useShallow((state) => ({
     messages: state.messages,
     sessions: state.sessions,
@@ -243,6 +245,8 @@ export function MainAIChatShell() {
     checkFirstLoad: state.checkFirstLoad,
     config: state.config,
     totalTokensUsed: state.totalTokensUsed,
+    pendingInputAppends: state.pendingInputAppends,
+    consumeInputAppends: state.consumeInputAppends,
   })));
 
   useRAGStore();
@@ -684,6 +688,18 @@ export function MainAIChatShell() {
     window.addEventListener('ai-input-append', handleAppendInput as EventListener);
     return () => window.removeEventListener('ai-input-append', handleAppendInput as EventListener);
   }, []);
+
+  useEffect(() => {
+    if (pendingInputAppends.length === 0) {
+      return;
+    }
+    setInput((prev) => {
+      const appended = pendingInputAppends.join("\n\n");
+      return prev ? `${prev}\n\n${appended}` : appended;
+    });
+    consumeInputAppends();
+    textareaRef.current?.focus();
+  }, [pendingInputAppends, consumeInputAppends]);
 
   // 检测输入是否仅仅是一个网页链接
   const isOnlyWebLink = useCallback((text: string): string | null => {

--- a/src/components/pdf/AnnotationPopover.tsx
+++ b/src/components/pdf/AnnotationPopover.tsx
@@ -107,7 +107,7 @@ export function AnnotationPopover({ className }: AnnotationPopoverProps) {
     setFloatingPanelOpen(true);
 
     if (mode === 'research') {
-      window.dispatchEvent(new CustomEvent('ai-input-append', { detail: { text: citationText } }));
+      useAIStore.getState().enqueueInputAppend(citationText);
     } else if (mode === 'codex') {
       try {
         await navigator.clipboard.writeText(citationText);

--- a/src/stores/useAIStore.ts
+++ b/src/stores/useAIStore.ts
@@ -140,6 +140,9 @@ interface AIState {
   addTextSelection: (text: string, source: string, sourcePath?: string) => void;
   removeTextSelection: (id: string) => void;
   clearTextSelections: () => void;
+  pendingInputAppends: string[];
+  enqueueInputAppend: (text: string) => void;
+  consumeInputAppends: () => string[];
 
   // Actions
   sendMessage: (content: string, currentFile?: { path: string; name: string; content: string }, displayContent?: string, images?: AttachedImage[]) => Promise<void>;
@@ -300,6 +303,21 @@ export const useAIStore = create<AIState>()(
       },
       clearTextSelections: () => {
         set({ textSelections: [] });
+      },
+      pendingInputAppends: [],
+      enqueueInputAppend: (text) => {
+        const trimmed = text.trim();
+        if (!trimmed) return;
+        set((state) => ({
+          pendingInputAppends: [...state.pendingInputAppends, trimmed],
+        }));
+      },
+      consumeInputAppends: () => {
+        const pending = get().pendingInputAppends;
+        if (pending.length > 0) {
+          set({ pendingInputAppends: [] });
+        }
+        return pending;
       },
 
       // Send message


### PR DESCRIPTION
## Summary\n- add PDF selection popover action to send selected text into AI flows\n- support Chat/Agent via quoted references, DeepResearch via input append, and Codex mode switch fallback\n- optimize popover interaction with compact AI mode menu\n- add tests for ai-input-append behavior in MainAIChatShell\n\n## Validation\n- npm run -s test:run -- src/components/layout/MainAIChatShell.test.tsx\n- npm run -s build