### PR TITLE
fix(pdf): send selection quote to current AI conversation

### DIFF
--- a/src/components/pdf/AnnotationPopover.tsx
+++ b/src/components/pdf/AnnotationPopover.tsx
@@ -21,6 +21,7 @@ export function AnnotationPopover({ className }: AnnotationPopoverProps) {
   const { popover, closePopover, addAnnotation } = usePDFAnnotationStore();
   const { currentPage } = usePDFStore();
   const { t } = useLocaleStore();
+  const chatMode = useUIStore((state) => state.chatMode);
   const setRightPanelTab = useUIStore((state) => state.setRightPanelTab);
   const setRightSidebarOpen = useUIStore((state) => state.setRightSidebarOpen);
   const setFloatingPanelOpen = useUIStore((state) => state.setFloatingPanelOpen);
@@ -99,10 +100,18 @@ export function AnnotationPopover({ className }: AnnotationPopoverProps) {
     setRightSidebarOpen(true);
     setRightPanelTab('chat');
     setFloatingPanelOpen(true);
-    useAIStore.getState().addTextSelection(citationText, source);
+    if (chatMode === 'research') {
+      useAIStore.getState().enqueueInputAppend(citationText);
+    } else if (chatMode === 'codex') {
+      navigator.clipboard.writeText(citationText).catch((err) => {
+        console.warn('Failed to copy PDF selection for Codex:', err);
+      });
+    } else {
+      useAIStore.getState().addTextSelection(citationText, source);
+    }
     closePopover();
     window.getSelection()?.removeAllRanges();
-  }, [popover.selectedText, currentPage, setRightSidebarOpen, setRightPanelTab, setFloatingPanelOpen, closePopover]);
+  }, [popover.selectedText, currentPage, chatMode, setRightSidebarOpen, setRightPanelTab, setFloatingPanelOpen, closePopover]);
   
   if (!popover.isOpen) return null;
   


### PR DESCRIPTION
## Summary\n- simplify PDF selection popover AI action to a single quote-send action\n- remove mode chooser and do not force mode switching\n- always send selected PDF text as reference quote into current AI conversation input context\n\n## Validation\n- npm run -s test:run -- src/components/layout/MainAIChatShell.test.tsx\n- npm run -s build