### PR TITLE
fix(editor): make cursor visible in dark mode

### DIFF
--- a/src/editor/CodeMirrorEditor.tsx
+++ b/src/editor/CodeMirrorEditor.tsx
@@ -78,7 +78,8 @@ export interface CodeMirrorEditorRef {
 
 const editorTheme = EditorView.theme({
   "&": { backgroundColor: "transparent", fontSize: "16px", height: "100%" },
-  ".cm-content": { fontFamily: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif", padding: "16px 0", caretColor: "hsl(var(--primary))" },
+  ".cm-content": { fontFamily: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif", padding: "16px 0", caretColor: "hsl(var(--foreground))" },
+  ".cm-cursor, .cm-dropCursor": { borderLeftColor: "hsl(var(--foreground))" },
   ".cm-line": { padding: "0 16px", paddingLeft: "16px", lineHeight: "1.75", position: "relative" },
 
   // 选区颜色（更淡的蓝色）

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1310,7 +1310,12 @@ mark {
 }
 
 .dark .codemirror-wrapper .cm-content {
-  caret-color: hsl(var(--primary));
+  caret-color: hsl(var(--foreground));
+}
+
+.dark .codemirror-wrapper .cm-cursor,
+.dark .codemirror-wrapper .cm-dropCursor {
+  border-left-color: hsl(var(--foreground)) !important;
 }
 
 .dark .codemirror-wrapper .cm-code {


### PR DESCRIPTION
CodeMirror uses a custom .cm-cursor div (border-left) instead of the native caret. The previous caretColor on .cm-content had no effect on this element, leaving a black cursor invisible on dark backgrounds.

- Add .cm-cursor/.cm-dropCursor borderLeftColor using --foreground
- Switch caret-color fallback from --primary to --foreground
- Add dark-mode override in globals.css for .cm-cursor