### PR TITLE
docs: expand README localization coverage

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -1,0 +1,181 @@
+<div align="center">
+
+<img src="src-tauri/icons/128x128.png" alt="Lumina Note Logo" width="120" height="120" />
+
+# Lumina Note
+
+**Local-first KI-Notiz-App**
+
+Deine Notizen bleiben auf deinem Gerät. Lumina Note hilft dir, Wissen mit KI zu schreiben, zu verknüpfen, zu durchsuchen und zu überarbeiten, ohne die Kontrolle über deine Daten abzugeben.
+
+[![GitHub Release](https://img.shields.io/github/v/release/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/releases)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg?style=flat-square)](LICENSE)
+[![Tauri](https://img.shields.io/badge/Tauri-v2-24C8DB?style=flat-square&logo=tauri&logoColor=white)](https://tauri.app/)
+
+[![CI](https://img.shields.io/github/actions/workflow/status/blueberrycongee/Lumina-Note/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/blueberrycongee/Lumina-Note/actions/workflows/ci.yml)
+[![Security Audit](https://img.shields.io/github/actions/workflow/status/blueberrycongee/Lumina-Note/security-audit.yml?branch=main&style=flat-square&label=Security%20Audit)](https://github.com/blueberrycongee/Lumina-Note/actions/workflows/security-audit.yml)
+[![Downloads](https://img.shields.io/github/downloads/blueberrycongee/Lumina-Note/total?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/releases)
+[![Last Commit](https://img.shields.io/github/last-commit/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/commits/main)
+[![GitHub Stars](https://img.shields.io/github/stars/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/stargazers)
+[![Commit Activity](https://img.shields.io/github/commit-activity/m/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/commits/main)
+![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS-lightgrey?style=flat-square)
+
+**Sprache**: [English](./README.md) · [简体中文](./README.zh-CN.md) · [繁體中文](./README.zh-TW.md) · [日本語](./README.ja.md) · [한국어](./README.ko.md) · [Español](./README.es.md) · [Français](./README.fr.md) · Deutsch · [Italiano](./README.it.md) · [Português (Brasil)](./README.pt-BR.md) · [Русский](./README.ru.md)
+
+</div>
+
+---
+
+<h2 align="center">Warum Lumina Note</h2>
+
+- **Local-first entwickelt**: Dein Vault bleibt lokal und du entscheidest, was an Modellanbieter gesendet wird.
+- **Auf Wissensarbeit ausgerichtet**: Markdown-Editor, WikiLinks, Graph-Ansicht und KI-Retrieval arbeiten als ein System zusammen.
+- **KI, die wirklich handelt**: `Chat`, `Agent`, `Deep Research` und `Codex` unterstützen echte Bearbeitungs- und Rechercheaufgaben.
+
+---
+
+<h2 align="center">Download</h2>
+
+<div align="center">
+
+Die neueste Version findest du unter [Releases](https://github.com/blueberrycongee/Lumina-Note/releases):
+
+| Plattform | Paket |
+|----------|-------|
+| Windows | `.msi` / `.exe` |
+| macOS (Intel) | `x64.dmg` |
+| macOS (Apple Silicon) | `aarch64.dmg` |
+
+</div>
+
+---
+
+<h2 align="center">Screenshots</h2>
+
+<p align="center">
+  <img src="docs/screenshots/ai-agent.png" alt="AI Agent" width="800" />
+</p>
+
+<p align="center">
+  <img src="docs/screenshots/knowledge-graph.png" alt="Knowledge Graph" width="800" />
+</p>
+
+<p align="center">
+  <img src="docs/screenshots/editor-latex.png" alt="Editor" width="800" />
+</p>
+
+---
+
+<h2 align="center">Funktionen</h2>
+
+<h3 align="center">KI-Workspace</h3>
+
+- Modi: `Chat` / `Agent` / `Deep Research` / `Codex` (eingebettete VS Code Erweiterung in der Seitenleiste)
+- Unterstützung für mehrere Anbieter: OpenAI / Anthropic (Claude) / DeepSeek / Gemini / Moonshot / Groq / OpenRouter / Ollama
+- Lokales semantisches Retrieval (RAG) aus deinem Vault
+
+<h3 align="center">Editor und Wissensgraph</h3>
+
+- Markdown-Quelltext / Live-Vorschau / Lesemodi
+- Bidirektionale Links mit `[[WikiLinks]]`
+- LaTeX, Mermaid und Syntax-Highlighting
+- Graph-Visualisierung für Beziehungen zwischen Notizen
+
+<h3 align="center">Lesen und Erfassen</h3>
+
+- Integrierter PDF-Reader mit Hervorhebungen, Unterstreichungen und Annotationen
+- Annotationen als Markdown speichern
+- Ausgewählte Inhalte direkt in den KI-Kontext senden
+
+<h3 align="center">Weitere Fähigkeiten</h3>
+
+- Bilibili-Video-Notizen mit Danmaku-Zeitstempel-Synchronisierung
+- Spracheingabe in Echtzeit
+- Datenbankansichten (Tabelle / Kanban)
+- WebDAV-Synchronisierung
+- Flashcard-Wiederholung
+- 15 Themes
+
+<h3 align="center">Plugin-Ökosystem (Developer Preview)</h3>
+
+- Plugins aus workspace / user / built-in Verzeichnissen laden
+- Laufzeit-Permissionsmodell für Plugin-Fähigkeiten
+- Slash-Command-Erweiterungs-API
+- Entwicklerleitfaden: `docs/plugin-ecosystem.md`
+
+---
+
+<h2 align="center">Schnellstart</h2>
+
+1. Installiere Lumina Note aus den Releases.
+2. Wähle beim ersten Start einen lokalen Ordner als Vault.
+3. Konfiguriere im KI-Panel einen Modellanbieter und deinen API-Schlüssel.
+4. Erstelle deine erste Notiz und verknüpfe sie mit `[[WikiLinks]]`.
+
+---
+
+<h2 align="center">Guides</h2>
+
+<h3 align="center">Empfohlene Benutzerleitfäden</h3>
+
+- English: `docs/user-flow.md`
+- 简体中文: `docs/user-flow.zh-CN.md`
+- 日本語: `docs/user-flow.ja.md`
+
+<h3 align="center">Selbst gehostetes Relay (netzübergreifender mobiler Zugriff)</h3>
+
+- English: `docs/self-host.md`
+- 简体中文: `docs/self-host.zh-CN.md`
+
+---
+
+<h2 align="center">Aus dem Quellcode bauen</h2>
+
+Voraussetzungen:
+
+- Node.js 20+ (empfohlen 20.11.1)
+- Rust 1.70+
+
+```bash
+git clone https://github.com/blueberrycongee/Lumina-Note.git
+cd Lumina-Note
+npm install
+npm run tauri dev
+```
+
+---
+
+<h2 align="center">Tech-Stack</h2>
+
+- Framework: Tauri v2 (Rust + WebView)
+- Frontend: React 18, TypeScript, Tailwind CSS
+- Editor: CodeMirror 6
+- State-Management: Zustand
+- Vektorspeicher: SQLite
+
+---
+
+<h2 align="center">Open-Source-Komponenten</h2>
+
+- Editor-Kern: [codemirror-live-markdown](https://github.com/blueberrycongee/codemirror-live-markdown)
+- Rust-Orchestrierungs-Runtime: [forge](https://github.com/blueberrycongee/forge)
+
+---
+
+<h2 align="center">Mitwirkende</h2>
+
+<a href="https://github.com/blueberrycongee/Lumina-Note/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=blueberrycongee/Lumina-Note" />
+</a>
+
+---
+
+<h2 align="center">Lizenz</h2>
+
+[Apache License 2.0](LICENSE)
+
+---
+
+<h2 align="center">Star History</h2>
+
+[![Star History Chart](https://api.star-history.com/svg?repos=blueberrycongee/Lumina-Note&type=Date)](https://star-history.com/#blueberrycongee/Lumina-Note&Date)

--- a/README.en.md
+++ b/README.en.md
@@ -6,7 +6,7 @@
 
 **Local-first AI note-taking app**
 
-Your notes stay on your device. Lumina Note helps you write, connect, and evolve knowledge with AI, while keeping data ownership in your hands.
+Your notes stay on your device. Lumina Note helps you write, connect, search, and refine knowledge with AI while keeping data ownership in your hands.
 
 [![GitHub Release](https://img.shields.io/github/v/release/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg?style=flat-square)](LICENSE)
@@ -20,7 +20,7 @@ Your notes stay on your device. Lumina Note helps you write, connect, and evolve
 [![Commit Activity](https://img.shields.io/github/commit-activity/m/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/commits/main)
 ![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS-lightgrey?style=flat-square)
 
-**Language**: English · [简体中文](./README.zh-CN.md) · [日本語](./README.ja.md)
+**Language**: English · [简体中文](./README.zh-CN.md) · [繁體中文](./README.zh-TW.md) · [日本語](./README.ja.md) · [한국어](./README.ko.md) · [Español](./README.es.md) · [Français](./README.fr.md) · [Deutsch](./README.de.md) · [Italiano](./README.it.md) · [Português (Brasil)](./README.pt-BR.md) · [Русский](./README.ru.md)
 
 </div>
 
@@ -28,9 +28,9 @@ Your notes stay on your device. Lumina Note helps you write, connect, and evolve
 
 <h2 align="center">Why Lumina Note</h2>
 
-- **Local-first by design**: your vault is local, and you decide what to send to model providers.
-- **Knowledge-centered workflow**: Markdown editor, WikiLinks, and graph view work together naturally.
-- **AI that can actually act**: Chat, Agent, Deep Research, and Codex mode support real editing and retrieval tasks.
+- **Local-first by design**: your vault is local, and you decide what gets sent to model providers.
+- **Knowledge-centered workflow**: Markdown editing, WikiLinks, graph view, and AI retrieval work as one system.
+- **AI that can actually act**: Chat, Agent, Deep Research, and Codex mode support real editing and research tasks.
 
 ---
 
@@ -69,23 +69,27 @@ Get the latest build from [Releases](https://github.com/blueberrycongee/Lumina-N
 <h2 align="center">Features</h2>
 
 <h3 align="center">AI workspace</h3>
-- Modes: `Chat` / `Agent` / `Deep Research` / `Codex` (embedded VS Code extension in sidebar)
+
+- Modes: `Chat` / `Agent` / `Deep Research` / `Codex` (embedded VS Code extension in the sidebar)
 - Multi-provider support: OpenAI / Anthropic (Claude) / DeepSeek / Gemini / Moonshot / Groq / OpenRouter / Ollama
 - Local semantic retrieval (RAG) from your vault
 
 <h3 align="center">Editor and knowledge graph</h3>
+
 - Markdown source / live preview / reading modes
 - Bidirectional links with `[[WikiLinks]]`
-- LaTeX, Mermaid, code highlighting
+- LaTeX, Mermaid, and code highlighting
 - Graph visualization for relationships across notes
 
 <h3 align="center">Reading and capture</h3>
+
 - Built-in PDF reader with highlight, underline, and annotations
-- Save annotation results as Markdown
-- Send selected content directly to AI context
+- Save annotation output as Markdown
+- Send selected content directly into AI context
 
 <h3 align="center">Extra capabilities</h3>
-- Bilibili video notes (danmaku timestamp sync)
+
+- Bilibili video notes with danmaku timestamp sync
 - Real-time voice input
 - Database views (table / kanban)
 - WebDAV sync
@@ -93,6 +97,7 @@ Get the latest build from [Releases](https://github.com/blueberrycongee/Lumina-N
 - 15 themes
 
 <h3 align="center">Plugin ecosystem (Developer Preview)</h3>
+
 - Load plugins from workspace / user / built-in directories
 - Runtime permission model for plugin capabilities
 - Slash command extension API
@@ -104,7 +109,7 @@ Get the latest build from [Releases](https://github.com/blueberrycongee/Lumina-N
 
 1. Install Lumina Note from Releases.
 2. Choose a local folder as your vault on first launch.
-3. Configure model provider + API key in the right AI panel.
+3. Configure a model provider and API key in the AI panel.
 4. Create your first note and start linking with `[[WikiLinks]]`.
 
 ---
@@ -112,11 +117,13 @@ Get the latest build from [Releases](https://github.com/blueberrycongee/Lumina-N
 <h2 align="center">Guides</h2>
 
 <h3 align="center">Recommended user guides</h3>
+
 - English: `docs/user-flow.md`
 - 简体中文: `docs/user-flow.zh-CN.md`
 - 日本語: `docs/user-flow.ja.md`
 
 <h3 align="center">Self-hosted relay (cross-network mobile access)</h3>
+
 - English: `docs/self-host.md`
 - 简体中文: `docs/self-host.zh-CN.md`
 
@@ -125,6 +132,7 @@ Get the latest build from [Releases](https://github.com/blueberrycongee/Lumina-N
 <h2 align="center">Build from Source</h2>
 
 Requirements:
+
 - Node.js 20+ (recommended 20.11.1)
 - Rust 1.70+
 

--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,181 @@
+<div align="center">
+
+<img src="src-tauri/icons/128x128.png" alt="Lumina Note Logo" width="120" height="120" />
+
+# Lumina Note
+
+**Aplicación de notas con IA y enfoque local-first**
+
+Tus notas permanecen en tu dispositivo. Lumina Note te ayuda a escribir, conectar, buscar y refinar conocimiento con IA sin perder el control de tus datos.
+
+[![GitHub Release](https://img.shields.io/github/v/release/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/releases)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg?style=flat-square)](LICENSE)
+[![Tauri](https://img.shields.io/badge/Tauri-v2-24C8DB?style=flat-square&logo=tauri&logoColor=white)](https://tauri.app/)
+
+[![CI](https://img.shields.io/github/actions/workflow/status/blueberrycongee/Lumina-Note/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/blueberrycongee/Lumina-Note/actions/workflows/ci.yml)
+[![Security Audit](https://img.shields.io/github/actions/workflow/status/blueberrycongee/Lumina-Note/security-audit.yml?branch=main&style=flat-square&label=Security%20Audit)](https://github.com/blueberrycongee/Lumina-Note/actions/workflows/security-audit.yml)
+[![Downloads](https://img.shields.io/github/downloads/blueberrycongee/Lumina-Note/total?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/releases)
+[![Last Commit](https://img.shields.io/github/last-commit/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/commits/main)
+[![GitHub Stars](https://img.shields.io/github/stars/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/stargazers)
+[![Commit Activity](https://img.shields.io/github/commit-activity/m/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/commits/main)
+![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS-lightgrey?style=flat-square)
+
+**Idioma**: [English](./README.md) · [简体中文](./README.zh-CN.md) · [繁體中文](./README.zh-TW.md) · [日本語](./README.ja.md) · [한국어](./README.ko.md) · Español · [Français](./README.fr.md) · [Deutsch](./README.de.md) · [Italiano](./README.it.md) · [Português (Brasil)](./README.pt-BR.md) · [Русский](./README.ru.md)
+
+</div>
+
+---
+
+<h2 align="center">Por qué Lumina Note</h2>
+
+- **Diseño local-first**: tu vault permanece en local y tú decides qué se envía a los proveedores de modelos.
+- **Flujo de trabajo centrado en el conocimiento**: edición Markdown, WikiLinks, vista de grafo y recuperación con IA funcionan como un solo sistema.
+- **IA que realmente actúa**: `Chat`, `Agent`, `Deep Research` y `Codex` apoyan tareas reales de edición e investigación.
+
+---
+
+<h2 align="center">Descarga</h2>
+
+<div align="center">
+
+Obtén la versión más reciente desde [Releases](https://github.com/blueberrycongee/Lumina-Note/releases):
+
+| Plataforma | Paquete |
+|-----------|---------|
+| Windows | `.msi` / `.exe` |
+| macOS (Intel) | `x64.dmg` |
+| macOS (Apple Silicon) | `aarch64.dmg` |
+
+</div>
+
+---
+
+<h2 align="center">Capturas de pantalla</h2>
+
+<p align="center">
+  <img src="docs/screenshots/ai-agent.png" alt="AI Agent" width="800" />
+</p>
+
+<p align="center">
+  <img src="docs/screenshots/knowledge-graph.png" alt="Knowledge Graph" width="800" />
+</p>
+
+<p align="center">
+  <img src="docs/screenshots/editor-latex.png" alt="Editor" width="800" />
+</p>
+
+---
+
+<h2 align="center">Funciones</h2>
+
+<h3 align="center">Espacio de trabajo de IA</h3>
+
+- Modos: `Chat` / `Agent` / `Deep Research` / `Codex` (extensión integrada de VS Code en la barra lateral)
+- Soporte para múltiples proveedores: OpenAI / Anthropic (Claude) / DeepSeek / Gemini / Moonshot / Groq / OpenRouter / Ollama
+- Recuperación semántica local (RAG) sobre tu vault
+
+<h3 align="center">Editor y grafo de conocimiento</h3>
+
+- Modos de código Markdown / vista previa en vivo / lectura
+- Enlaces bidireccionales con `[[WikiLinks]]`
+- LaTeX, Mermaid y resaltado de código
+- Visualización en grafo de las relaciones entre notas
+
+<h3 align="center">Lectura y captura</h3>
+
+- Lector PDF integrado con resaltado, subrayado y anotaciones
+- Guarda el resultado de las anotaciones como Markdown
+- Envía contenido seleccionado directamente al contexto de IA
+
+<h3 align="center">Capacidades adicionales</h3>
+
+- Notas de video de Bilibili con sincronización de marcas de tiempo de danmaku
+- Entrada de voz en tiempo real
+- Vistas de base de datos (tabla / kanban)
+- Sincronización WebDAV
+- Repaso con flashcards
+- 15 temas
+
+<h3 align="center">Ecosistema de plugins (Developer Preview)</h3>
+
+- Carga plugins desde directorios workspace / user / built-in
+- Modelo de permisos en tiempo de ejecución para capacidades del plugin
+- API de extensión para Slash Command
+- Guía para desarrolladores: `docs/plugin-ecosystem.md`
+
+---
+
+<h2 align="center">Inicio rápido</h2>
+
+1. Instala Lumina Note desde Releases.
+2. Elige una carpeta local como tu vault en el primer inicio.
+3. Configura un proveedor de modelos y tu API key en el panel de IA.
+4. Crea tu primera nota y empieza a enlazar con `[[WikiLinks]]`.
+
+---
+
+<h2 align="center">Guías</h2>
+
+<h3 align="center">Guías recomendadas</h3>
+
+- English: `docs/user-flow.md`
+- 简体中文: `docs/user-flow.zh-CN.md`
+- 日本語: `docs/user-flow.ja.md`
+
+<h3 align="center">Relay autohospedado (acceso móvil entre redes)</h3>
+
+- English: `docs/self-host.md`
+- 简体中文: `docs/self-host.zh-CN.md`
+
+---
+
+<h2 align="center">Compilar desde el código fuente</h2>
+
+Requisitos:
+
+- Node.js 20+ (recomendado 20.11.1)
+- Rust 1.70+
+
+```bash
+git clone https://github.com/blueberrycongee/Lumina-Note.git
+cd Lumina-Note
+npm install
+npm run tauri dev
+```
+
+---
+
+<h2 align="center">Stack técnico</h2>
+
+- Framework: Tauri v2 (Rust + WebView)
+- Frontend: React 18, TypeScript, Tailwind CSS
+- Editor: CodeMirror 6
+- Estado: Zustand
+- Almacenamiento vectorial: SQLite
+
+---
+
+<h2 align="center">Componentes de código abierto</h2>
+
+- Núcleo del editor: [codemirror-live-markdown](https://github.com/blueberrycongee/codemirror-live-markdown)
+- Runtime de orquestación en Rust: [forge](https://github.com/blueberrycongee/forge)
+
+---
+
+<h2 align="center">Contribuidores</h2>
+
+<a href="https://github.com/blueberrycongee/Lumina-Note/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=blueberrycongee/Lumina-Note" />
+</a>
+
+---
+
+<h2 align="center">Licencia</h2>
+
+[Apache License 2.0](LICENSE)
+
+---
+
+<h2 align="center">Star History</h2>
+
+[![Star History Chart](https://api.star-history.com/svg?repos=blueberrycongee/Lumina-Note&type=Date)](https://star-history.com/#blueberrycongee/Lumina-Note&Date)

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,0 +1,181 @@
+<div align="center">
+
+<img src="src-tauri/icons/128x128.png" alt="Lumina Note Logo" width="120" height="120" />
+
+# Lumina Note
+
+**Application de prise de notes IA en local-first**
+
+Vos notes restent sur votre appareil. Lumina Note vous aide à écrire, relier, rechercher et affiner vos connaissances avec l'IA tout en gardant le contrôle de vos données.
+
+[![GitHub Release](https://img.shields.io/github/v/release/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/releases)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg?style=flat-square)](LICENSE)
+[![Tauri](https://img.shields.io/badge/Tauri-v2-24C8DB?style=flat-square&logo=tauri&logoColor=white)](https://tauri.app/)
+
+[![CI](https://img.shields.io/github/actions/workflow/status/blueberrycongee/Lumina-Note/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/blueberrycongee/Lumina-Note/actions/workflows/ci.yml)
+[![Security Audit](https://img.shields.io/github/actions/workflow/status/blueberrycongee/Lumina-Note/security-audit.yml?branch=main&style=flat-square&label=Security%20Audit)](https://github.com/blueberrycongee/Lumina-Note/actions/workflows/security-audit.yml)
+[![Downloads](https://img.shields.io/github/downloads/blueberrycongee/Lumina-Note/total?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/releases)
+[![Last Commit](https://img.shields.io/github/last-commit/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/commits/main)
+[![GitHub Stars](https://img.shields.io/github/stars/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/stargazers)
+[![Commit Activity](https://img.shields.io/github/commit-activity/m/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/commits/main)
+![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS-lightgrey?style=flat-square)
+
+**Langue** : [English](./README.md) · [简体中文](./README.zh-CN.md) · [繁體中文](./README.zh-TW.md) · [日本語](./README.ja.md) · [한국어](./README.ko.md) · [Español](./README.es.md) · Français · [Deutsch](./README.de.md) · [Italiano](./README.it.md) · [Português (Brasil)](./README.pt-BR.md) · [Русский](./README.ru.md)
+
+</div>
+
+---
+
+<h2 align="center">Pourquoi Lumina Note</h2>
+
+- **Conçu en local-first** : votre vault reste en local et vous décidez ce qui part vers les fournisseurs de modèles.
+- **Flux de travail centré sur la connaissance** : édition Markdown, WikiLinks, vue graphe et recherche IA fonctionnent comme un seul système.
+- **Une IA qui agit vraiment** : `Chat`, `Agent`, `Deep Research` et `Codex` prennent en charge de vraies tâches d'édition et de recherche.
+
+---
+
+<h2 align="center">Téléchargement</h2>
+
+<div align="center">
+
+Récupérez la dernière version depuis [Releases](https://github.com/blueberrycongee/Lumina-Note/releases) :
+
+| Plateforme | Paquet |
+|-----------|--------|
+| Windows | `.msi` / `.exe` |
+| macOS (Intel) | `x64.dmg` |
+| macOS (Apple Silicon) | `aarch64.dmg` |
+
+</div>
+
+---
+
+<h2 align="center">Captures d'écran</h2>
+
+<p align="center">
+  <img src="docs/screenshots/ai-agent.png" alt="AI Agent" width="800" />
+</p>
+
+<p align="center">
+  <img src="docs/screenshots/knowledge-graph.png" alt="Knowledge Graph" width="800" />
+</p>
+
+<p align="center">
+  <img src="docs/screenshots/editor-latex.png" alt="Editor" width="800" />
+</p>
+
+---
+
+<h2 align="center">Fonctionnalités</h2>
+
+<h3 align="center">Espace de travail IA</h3>
+
+- Modes : `Chat` / `Agent` / `Deep Research` / `Codex` (extension VS Code intégrée dans la barre latérale)
+- Support multi-fournisseurs : OpenAI / Anthropic (Claude) / DeepSeek / Gemini / Moonshot / Groq / OpenRouter / Ollama
+- Recherche sémantique locale (RAG) dans votre vault
+
+<h3 align="center">Éditeur et graphe de connaissances</h3>
+
+- Modes source Markdown / aperçu en direct / lecture
+- Liens bidirectionnels avec `[[WikiLinks]]`
+- LaTeX, Mermaid et coloration syntaxique
+- Visualisation en graphe des relations entre notes
+
+<h3 align="center">Lecture et capture</h3>
+
+- Lecteur PDF intégré avec surlignage, soulignement et annotations
+- Enregistrement des annotations en Markdown
+- Envoi direct du contenu sélectionné dans le contexte IA
+
+<h3 align="center">Capacités supplémentaires</h3>
+
+- Notes vidéo Bilibili avec synchronisation des horodatages de danmaku
+- Saisie vocale en temps réel
+- Vues base de données (tableau / kanban)
+- Synchronisation WebDAV
+- Révision par flashcards
+- 15 thèmes
+
+<h3 align="center">Écosystème de plugins (Developer Preview)</h3>
+
+- Chargement des plugins depuis les répertoires workspace / user / built-in
+- Modèle de permissions à l'exécution pour les capacités des plugins
+- API d'extension Slash Command
+- Guide développeur : `docs/plugin-ecosystem.md`
+
+---
+
+<h2 align="center">Démarrage rapide</h2>
+
+1. Installez Lumina Note depuis Releases.
+2. Choisissez un dossier local comme vault au premier lancement.
+3. Configurez un fournisseur de modèle et votre clé API dans le panneau IA.
+4. Créez votre première note et commencez à relier avec `[[WikiLinks]]`.
+
+---
+
+<h2 align="center">Guides</h2>
+
+<h3 align="center">Guides recommandés</h3>
+
+- English: `docs/user-flow.md`
+- 简体中文: `docs/user-flow.zh-CN.md`
+- 日本語: `docs/user-flow.ja.md`
+
+<h3 align="center">Relais auto-hébergé (accès mobile inter-réseaux)</h3>
+
+- English: `docs/self-host.md`
+- 简体中文: `docs/self-host.zh-CN.md`
+
+---
+
+<h2 align="center">Compiler depuis les sources</h2>
+
+Prérequis :
+
+- Node.js 20+ (recommandé 20.11.1)
+- Rust 1.70+
+
+```bash
+git clone https://github.com/blueberrycongee/Lumina-Note.git
+cd Lumina-Note
+npm install
+npm run tauri dev
+```
+
+---
+
+<h2 align="center">Pile technique</h2>
+
+- Framework : Tauri v2 (Rust + WebView)
+- Frontend : React 18, TypeScript, Tailwind CSS
+- Éditeur : CodeMirror 6
+- État : Zustand
+- Stockage vectoriel : SQLite
+
+---
+
+<h2 align="center">Composants open source</h2>
+
+- Cœur de l'éditeur : [codemirror-live-markdown](https://github.com/blueberrycongee/codemirror-live-markdown)
+- Runtime d'orchestration Rust : [forge](https://github.com/blueberrycongee/forge)
+
+---
+
+<h2 align="center">Contributeurs</h2>
+
+<a href="https://github.com/blueberrycongee/Lumina-Note/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=blueberrycongee/Lumina-Note" />
+</a>
+
+---
+
+<h2 align="center">Licence</h2>
+
+[Apache License 2.0](LICENSE)
+
+---
+
+<h2 align="center">Star History</h2>
+
+[![Star History Chart](https://api.star-history.com/svg?repos=blueberrycongee/Lumina-Note&type=Date)](https://star-history.com/#blueberrycongee/Lumina-Note&Date)

--- a/README.it.md
+++ b/README.it.md
@@ -1,0 +1,181 @@
+<div align="center">
+
+<img src="src-tauri/icons/128x128.png" alt="Lumina Note Logo" width="120" height="120" />
+
+# Lumina Note
+
+**App di note AI local-first**
+
+Le tue note restano sul tuo dispositivo. Lumina Note ti aiuta a scrivere, collegare, cercare e rifinire la conoscenza con l'AI mantenendo il controllo dei tuoi dati.
+
+[![GitHub Release](https://img.shields.io/github/v/release/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/releases)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg?style=flat-square)](LICENSE)
+[![Tauri](https://img.shields.io/badge/Tauri-v2-24C8DB?style=flat-square&logo=tauri&logoColor=white)](https://tauri.app/)
+
+[![CI](https://img.shields.io/github/actions/workflow/status/blueberrycongee/Lumina-Note/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/blueberrycongee/Lumina-Note/actions/workflows/ci.yml)
+[![Security Audit](https://img.shields.io/github/actions/workflow/status/blueberrycongee/Lumina-Note/security-audit.yml?branch=main&style=flat-square&label=Security%20Audit)](https://github.com/blueberrycongee/Lumina-Note/actions/workflows/security-audit.yml)
+[![Downloads](https://img.shields.io/github/downloads/blueberrycongee/Lumina-Note/total?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/releases)
+[![Last Commit](https://img.shields.io/github/last-commit/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/commits/main)
+[![GitHub Stars](https://img.shields.io/github/stars/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/stargazers)
+[![Commit Activity](https://img.shields.io/github/commit-activity/m/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/commits/main)
+![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS-lightgrey?style=flat-square)
+
+**Lingua**: [English](./README.md) · [简体中文](./README.zh-CN.md) · [繁體中文](./README.zh-TW.md) · [日本語](./README.ja.md) · [한국어](./README.ko.md) · [Español](./README.es.md) · [Français](./README.fr.md) · [Deutsch](./README.de.md) · Italiano · [Português (Brasil)](./README.pt-BR.md) · [Русский](./README.ru.md)
+
+</div>
+
+---
+
+<h2 align="center">Perché Lumina Note</h2>
+
+- **Progettato local-first**: il tuo vault resta in locale e decidi tu cosa inviare ai provider di modelli.
+- **Flusso di lavoro centrato sulla conoscenza**: editing Markdown, WikiLinks, vista grafo e recupero AI lavorano come un unico sistema.
+- **AI che agisce davvero**: `Chat`, `Agent`, `Deep Research` e `Codex` supportano attività reali di editing e ricerca.
+
+---
+
+<h2 align="center">Download</h2>
+
+<div align="center">
+
+Scarica l'ultima versione da [Releases](https://github.com/blueberrycongee/Lumina-Note/releases):
+
+| Piattaforma | Pacchetto |
+|------------|-----------|
+| Windows | `.msi` / `.exe` |
+| macOS (Intel) | `x64.dmg` |
+| macOS (Apple Silicon) | `aarch64.dmg` |
+
+</div>
+
+---
+
+<h2 align="center">Screenshot</h2>
+
+<p align="center">
+  <img src="docs/screenshots/ai-agent.png" alt="AI Agent" width="800" />
+</p>
+
+<p align="center">
+  <img src="docs/screenshots/knowledge-graph.png" alt="Knowledge Graph" width="800" />
+</p>
+
+<p align="center">
+  <img src="docs/screenshots/editor-latex.png" alt="Editor" width="800" />
+</p>
+
+---
+
+<h2 align="center">Funzionalità</h2>
+
+<h3 align="center">Workspace AI</h3>
+
+- Modalità: `Chat` / `Agent` / `Deep Research` / `Codex` (estensione VS Code integrata nella barra laterale)
+- Supporto multi-provider: OpenAI / Anthropic (Claude) / DeepSeek / Gemini / Moonshot / Groq / OpenRouter / Ollama
+- Recupero semantico locale (RAG) dal tuo vault
+
+<h3 align="center">Editor e grafo della conoscenza</h3>
+
+- Modalità sorgente Markdown / anteprima live / lettura
+- Collegamenti bidirezionali con `[[WikiLinks]]`
+- LaTeX, Mermaid e evidenziazione del codice
+- Visualizzazione a grafo delle relazioni tra note
+
+<h3 align="center">Lettura e acquisizione</h3>
+
+- Lettore PDF integrato con evidenziazione, sottolineatura e annotazioni
+- Salvataggio delle annotazioni in Markdown
+- Invio diretto del contenuto selezionato nel contesto AI
+
+<h3 align="center">Capacità aggiuntive</h3>
+
+- Note video Bilibili con sincronizzazione dei timestamp danmaku
+- Input vocale in tempo reale
+- Viste database (tabella / kanban)
+- Sincronizzazione WebDAV
+- Ripasso con flashcard
+- 15 temi
+
+<h3 align="center">Ecosistema plugin (Developer Preview)</h3>
+
+- Caricamento plugin da directory workspace / user / built-in
+- Modello di permessi runtime per le capacità dei plugin
+- API di estensione Slash Command
+- Guida per sviluppatori: `docs/plugin-ecosystem.md`
+
+---
+
+<h2 align="center">Avvio rapido</h2>
+
+1. Installa Lumina Note da Releases.
+2. Al primo avvio scegli una cartella locale come vault.
+3. Configura un provider di modelli e la tua API key nel pannello AI.
+4. Crea la tua prima nota e inizia a collegarla con `[[WikiLinks]]`.
+
+---
+
+<h2 align="center">Guide</h2>
+
+<h3 align="center">Guide consigliate</h3>
+
+- English: `docs/user-flow.md`
+- 简体中文: `docs/user-flow.zh-CN.md`
+- 日本語: `docs/user-flow.ja.md`
+
+<h3 align="center">Relay self-hosted (accesso mobile tra reti diverse)</h3>
+
+- English: `docs/self-host.md`
+- 简体中文: `docs/self-host.zh-CN.md`
+
+---
+
+<h2 align="center">Build dai sorgenti</h2>
+
+Requisiti:
+
+- Node.js 20+ (consigliato 20.11.1)
+- Rust 1.70+
+
+```bash
+git clone https://github.com/blueberrycongee/Lumina-Note.git
+cd Lumina-Note
+npm install
+npm run tauri dev
+```
+
+---
+
+<h2 align="center">Stack tecnico</h2>
+
+- Framework: Tauri v2 (Rust + WebView)
+- Frontend: React 18, TypeScript, Tailwind CSS
+- Editor: CodeMirror 6
+- State management: Zustand
+- Archiviazione vettoriale: SQLite
+
+---
+
+<h2 align="center">Componenti open source</h2>
+
+- Core editor: [codemirror-live-markdown](https://github.com/blueberrycongee/codemirror-live-markdown)
+- Runtime di orchestrazione Rust: [forge](https://github.com/blueberrycongee/forge)
+
+---
+
+<h2 align="center">Contributori</h2>
+
+<a href="https://github.com/blueberrycongee/Lumina-Note/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=blueberrycongee/Lumina-Note" />
+</a>
+
+---
+
+<h2 align="center">Licenza</h2>
+
+[Apache License 2.0](LICENSE)
+
+---
+
+<h2 align="center">Star History</h2>
+
+[![Star History Chart](https://api.star-history.com/svg?repos=blueberrycongee/Lumina-Note&type=Date)](https://star-history.com/#blueberrycongee/Lumina-Note&Date)

--- a/README.ja.md
+++ b/README.ja.md
@@ -6,7 +6,7 @@
 
 **ローカルファーストの AI ノートアプリ**
 
-ノートはデバイス上に保持しながら、AI で整理・検索・編集・調査を進められる知識ワークスペースです。
+ノートはデバイス上に保持したまま、AI を使って知識の記述、接続、検索、整理を進められるワークスペースです。
 
 [![GitHub Release](https://img.shields.io/github/v/release/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg?style=flat-square)](LICENSE)
@@ -20,7 +20,7 @@
 [![Commit Activity](https://img.shields.io/github/commit-activity/m/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/commits/main)
 ![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS-lightgrey?style=flat-square)
 
-**Language**: [English](./README.md) · [简体中文](./README.zh-CN.md) · 日本語
+**言語**: [English](./README.md) · [简体中文](./README.zh-CN.md) · [繁體中文](./README.zh-TW.md) · 日本語 · [한국어](./README.ko.md) · [Español](./README.es.md) · [Français](./README.fr.md) · [Deutsch](./README.de.md) · [Italiano](./README.it.md) · [Português (Brasil)](./README.pt-BR.md) · [Русский](./README.ru.md)
 
 </div>
 
@@ -28,9 +28,9 @@
 
 <h2 align="center">Lumina Note の特長</h2>
 
-- **ローカルファースト**: Vault はローカル管理。モデルに送る範囲を自分で決められます。
-- **知識中心の設計**: エディタ、WikiLinks、グラフが一体で機能します。
-- **実行できる AI**: Chat だけでなく Agent / Deep Research / Codex で実作業まで対応。
+- **ローカルファースト設計**: Vault はローカル管理で、モデルに送る内容を自分で選べます。
+- **知識作業をひとつに統合**: Markdown 編集、WikiLinks、グラフ表示、AI 検索が一体で動作します。
+- **実務に使える AI**: `Chat`、`Agent`、`Deep Research`、`Codex` が編集や調査タスクを支援します。
 
 ---
 
@@ -69,32 +69,37 @@
 <h2 align="center">機能</h2>
 
 <h3 align="center">AI ワークスペース</h3>
-- モード: `Chat` / `Agent` / `Deep Research` / `Codex`（サイドバー埋め込み VS Code 拡張）
+
+- モード: `Chat` / `Agent` / `Deep Research` / `Codex`（サイドバーに埋め込まれた VS Code 拡張）
 - 対応プロバイダ: OpenAI / Anthropic (Claude) / DeepSeek / Gemini / Moonshot / Groq / OpenRouter / Ollama
-- Vault 全体を対象にしたローカル意味検索（RAG）
+- Vault を対象にしたローカル意味検索（RAG）
 
 <h3 align="center">エディタとナレッジグラフ</h3>
+
 - Markdown ソース / ライブプレビュー / 閲覧モード
 - `[[WikiLinks]]` による双方向リンク
 - LaTeX、Mermaid、コードハイライト
-- ノート間の関係を可視化するグラフビュー
+- ノート間の関係を可視化するグラフ表示
 
-<h3 align="center">読書・収集</h3>
-- PDF リーダー（ハイライト、下線、注釈）
-- 注釈を Markdown として保存
-- 選択した内容を AI コンテキストへ送信
+<h3 align="center">読書と収集</h3>
 
-<h3 align="center">その他</h3>
+- ハイライト、下線、注釈に対応した内蔵 PDF リーダー
+- 注釈結果を Markdown として保存
+- 選択した内容をそのまま AI コンテキストへ送信
+
+<h3 align="center">追加機能</h3>
+
 - Bilibili 動画ノート（弾幕タイムスタンプ同期）
-- 音声入力（リアルタイム文字起こし）
+- リアルタイム音声入力
 - データベースビュー（テーブル / カンバン）
 - WebDAV 同期
 - フラッシュカード復習
-- 15 テーマ
+- 15 種類のテーマ
 
 <h3 align="center">プラグインエコシステム（開発者プレビュー）</h3>
+
 - workspace / user / built-in ディレクトリからプラグインを読み込み
-- ランタイム権限モデル
+- プラグイン機能向けのランタイム権限モデル
 - Slash Command 拡張 API
 - 開発者向けガイド: `docs/plugin-ecosystem.md`
 
@@ -102,21 +107,23 @@
 
 <h2 align="center">クイックスタート</h2>
 
-1. Releases からアプリをインストール
-2. 初回起動でローカルフォルダを Vault に指定
-3. 右側 AI パネルでモデルと API Key を設定
-4. 最初のノートを作成し、`[[WikiLinks]]` で関連付け
+1. Releases から Lumina Note をインストール
+2. 初回起動時にローカルフォルダを Vault として選択
+3. AI パネルでモデルプロバイダと API Key を設定
+4. 最初のノートを作成し、`[[WikiLinks]]` でつなげる
 
 ---
 
 <h2 align="center">ガイド</h2>
 
-<h3 align="center">まず読むガイド</h3>
-- 日本語: `docs/user-flow.ja.md`
+<h3 align="center">おすすめのユーザーガイド</h3>
+
 - English: `docs/user-flow.md`
 - 简体中文: `docs/user-flow.zh-CN.md`
+- 日本語: `docs/user-flow.ja.md`
 
 <h3 align="center">セルフホスト中継（クロスネットワークのモバイルアクセス）</h3>
+
 - English: `docs/self-host.md`
 - 简体中文: `docs/self-host.zh-CN.md`
 
@@ -125,6 +132,7 @@
 <h2 align="center">ソースからビルド</h2>
 
 必要環境:
+
 - Node.js 20+（推奨 20.11.1）
 - Rust 1.70+
 
@@ -139,8 +147,8 @@ npm run tauri dev
 
 <h2 align="center">技術スタック</h2>
 
-- フレームワーク: Tauri v2 (Rust + WebView)
-- フロントエンド: React 18, TypeScript, Tailwind CSS
+- フレームワーク: Tauri v2（Rust + WebView）
+- フロントエンド: React 18、TypeScript、Tailwind CSS
 - エディタ: CodeMirror 6
 - 状態管理: Zustand
 - ベクトルストレージ: SQLite

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,181 @@
+<div align="center">
+
+<img src="src-tauri/icons/128x128.png" alt="Lumina Note Logo" width="120" height="120" />
+
+# Lumina Note
+
+**로컬 우선 AI 노트 앱**
+
+노트는 기본적으로 내 기기에 남고, Lumina Note 는 AI 로 지식을 작성하고 연결하고 검색하고 다듬을 수 있게 해 주면서도 데이터 통제권을 사용자에게 남겨 둡니다.
+
+[![GitHub Release](https://img.shields.io/github/v/release/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/releases)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg?style=flat-square)](LICENSE)
+[![Tauri](https://img.shields.io/badge/Tauri-v2-24C8DB?style=flat-square&logo=tauri&logoColor=white)](https://tauri.app/)
+
+[![CI](https://img.shields.io/github/actions/workflow/status/blueberrycongee/Lumina-Note/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/blueberrycongee/Lumina-Note/actions/workflows/ci.yml)
+[![Security Audit](https://img.shields.io/github/actions/workflow/status/blueberrycongee/Lumina-Note/security-audit.yml?branch=main&style=flat-square&label=Security%20Audit)](https://github.com/blueberrycongee/Lumina-Note/actions/workflows/security-audit.yml)
+[![Downloads](https://img.shields.io/github/downloads/blueberrycongee/Lumina-Note/total?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/releases)
+[![Last Commit](https://img.shields.io/github/last-commit/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/commits/main)
+[![GitHub Stars](https://img.shields.io/github/stars/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/stargazers)
+[![Commit Activity](https://img.shields.io/github/commit-activity/m/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/commits/main)
+![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS-lightgrey?style=flat-square)
+
+**언어**: [English](./README.md) · [简体中文](./README.zh-CN.md) · [繁體中文](./README.zh-TW.md) · [日本語](./README.ja.md) · 한국어 · [Español](./README.es.md) · [Français](./README.fr.md) · [Deutsch](./README.de.md) · [Italiano](./README.it.md) · [Português (Brasil)](./README.pt-BR.md) · [Русский](./README.ru.md)
+
+</div>
+
+---
+
+<h2 align="center">왜 Lumina Note 인가</h2>
+
+- **로컬 우선 설계**: 볼트는 로컬에 보관되며, 어떤 내용을 모델 제공자에게 보낼지 직접 결정할 수 있습니다.
+- **지식 작업 흐름 중심**: Markdown 편집, WikiLinks, 그래프 뷰, AI 검색이 하나의 시스템으로 이어집니다.
+- **실제로 작업하는 AI**: `Chat`, `Agent`, `Deep Research`, `Codex` 모드가 편집과 리서치 작업을 지원합니다.
+
+---
+
+<h2 align="center">다운로드</h2>
+
+<div align="center">
+
+최신 빌드는 [Releases](https://github.com/blueberrycongee/Lumina-Note/releases) 에서 받을 수 있습니다.
+
+| 플랫폼 | 패키지 |
+|--------|--------|
+| Windows | `.msi` / `.exe` |
+| macOS (Intel) | `x64.dmg` |
+| macOS (Apple Silicon) | `aarch64.dmg` |
+
+</div>
+
+---
+
+<h2 align="center">스크린샷</h2>
+
+<p align="center">
+  <img src="docs/screenshots/ai-agent.png" alt="AI Agent" width="800" />
+</p>
+
+<p align="center">
+  <img src="docs/screenshots/knowledge-graph.png" alt="지식 그래프" width="800" />
+</p>
+
+<p align="center">
+  <img src="docs/screenshots/editor-latex.png" alt="에디터" width="800" />
+</p>
+
+---
+
+<h2 align="center">기능</h2>
+
+<h3 align="center">AI 워크스페이스</h3>
+
+- 모드: `Chat` / `Agent` / `Deep Research` / `Codex` (사이드바에 내장된 VS Code 확장)
+- 다중 모델 제공자 지원: OpenAI / Anthropic (Claude) / DeepSeek / Gemini / Moonshot / Groq / OpenRouter / Ollama
+- 로컬 볼트를 대상으로 한 시맨틱 검색(RAG)
+
+<h3 align="center">에디터와 지식 그래프</h3>
+
+- Markdown 소스 / 라이브 프리뷰 / 읽기 모드
+- `[[WikiLinks]]` 양방향 링크
+- LaTeX, Mermaid, 코드 하이라이팅
+- 노트 관계를 시각화하는 그래프 뷰
+
+<h3 align="center">읽기와 수집</h3>
+
+- 하이라이트, 밑줄, 주석을 지원하는 내장 PDF 리더
+- 주석 결과를 Markdown 으로 저장
+- 선택한 내용을 바로 AI 컨텍스트로 전송
+
+<h3 align="center">추가 기능</h3>
+
+- Bilibili 비디오 노트(탄막 타임스탬프 동기화)
+- 실시간 음성 입력
+- 데이터베이스 뷰(테이블 / 칸반)
+- WebDAV 동기화
+- 플래시카드 복습
+- 15개 테마
+
+<h3 align="center">플러그인 생태계 (Developer Preview)</h3>
+
+- workspace / user / built-in 디렉터리에서 플러그인 로드
+- 플러그인 기능을 위한 런타임 권한 모델
+- Slash Command 확장 API
+- 개발자 가이드: `docs/plugin-ecosystem.md`
+
+---
+
+<h2 align="center">빠른 시작</h2>
+
+1. Releases 에서 Lumina Note 를 설치합니다.
+2. 처음 실행할 때 로컬 폴더를 볼트로 선택합니다.
+3. AI 패널에서 모델 제공자와 API 키를 설정합니다.
+4. 첫 노트를 만들고 `[[WikiLinks]]` 로 연결을 시작합니다.
+
+---
+
+<h2 align="center">가이드</h2>
+
+<h3 align="center">추천 사용자 가이드</h3>
+
+- English: `docs/user-flow.md`
+- 简体中文: `docs/user-flow.zh-CN.md`
+- 日本語: `docs/user-flow.ja.md`
+
+<h3 align="center">셀프호스트 릴레이 (교차 네트워크 모바일 접속)</h3>
+
+- English: `docs/self-host.md`
+- 简体中文: `docs/self-host.zh-CN.md`
+
+---
+
+<h2 align="center">소스에서 빌드</h2>
+
+요구 사항:
+
+- Node.js 20+ (권장 20.11.1)
+- Rust 1.70+
+
+```bash
+git clone https://github.com/blueberrycongee/Lumina-Note.git
+cd Lumina-Note
+npm install
+npm run tauri dev
+```
+
+---
+
+<h2 align="center">기술 스택</h2>
+
+- 프레임워크: Tauri v2 (Rust + WebView)
+- 프론트엔드: React 18, TypeScript, Tailwind CSS
+- 에디터: CodeMirror 6
+- 상태 관리: Zustand
+- 벡터 저장소: SQLite
+
+---
+
+<h2 align="center">오픈 소스 컴포넌트</h2>
+
+- 에디터 코어: [codemirror-live-markdown](https://github.com/blueberrycongee/codemirror-live-markdown)
+- Rust 오케스트레이션 런타임: [forge](https://github.com/blueberrycongee/forge)
+
+---
+
+<h2 align="center">기여자</h2>
+
+<a href="https://github.com/blueberrycongee/Lumina-Note/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=blueberrycongee/Lumina-Note" />
+</a>
+
+---
+
+<h2 align="center">라이선스</h2>
+
+[Apache License 2.0](LICENSE)
+
+---
+
+<h2 align="center">Star History</h2>
+
+[![Star History Chart](https://api.star-history.com/svg?repos=blueberrycongee/Lumina-Note&type=Date)](https://star-history.com/#blueberrycongee/Lumina-Note&Date)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Local-first AI note-taking app**
 
-Your notes stay on your device. Lumina Note helps you write, connect, and evolve knowledge with AI, while keeping data ownership in your hands.
+Your notes stay on your device. Lumina Note helps you write, connect, search, and refine knowledge with AI while keeping data ownership in your hands.
 
 [![GitHub Release](https://img.shields.io/github/v/release/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg?style=flat-square)](LICENSE)
@@ -20,7 +20,7 @@ Your notes stay on your device. Lumina Note helps you write, connect, and evolve
 [![Commit Activity](https://img.shields.io/github/commit-activity/m/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/commits/main)
 ![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS-lightgrey?style=flat-square)
 
-**Language**: English (default) · [简体中文](./README.zh-CN.md) · [日本語](./README.ja.md)
+**Language**: English (default) · [简体中文](./README.zh-CN.md) · [繁體中文](./README.zh-TW.md) · [日本語](./README.ja.md) · [한국어](./README.ko.md) · [Español](./README.es.md) · [Français](./README.fr.md) · [Deutsch](./README.de.md) · [Italiano](./README.it.md) · [Português (Brasil)](./README.pt-BR.md) · [Русский](./README.ru.md)
 
 </div>
 
@@ -28,9 +28,9 @@ Your notes stay on your device. Lumina Note helps you write, connect, and evolve
 
 <h2 align="center">Why Lumina Note</h2>
 
-- **Local-first by design**: your vault is local, and you decide what to send to model providers.
-- **Knowledge-centered workflow**: Markdown editor, WikiLinks, and graph view work together naturally.
-- **AI that can actually act**: Chat, Agent, Deep Research, and Codex mode support real editing and retrieval tasks.
+- **Local-first by design**: your vault is local, and you decide what gets sent to model providers.
+- **Knowledge-centered workflow**: Markdown editing, WikiLinks, graph view, and AI retrieval work as one system.
+- **AI that can actually act**: Chat, Agent, Deep Research, and Codex mode support real editing and research tasks.
 
 ---
 
@@ -69,23 +69,27 @@ Get the latest build from [Releases](https://github.com/blueberrycongee/Lumina-N
 <h2 align="center">Features</h2>
 
 <h3 align="center">AI workspace</h3>
-- Modes: `Chat` / `Agent` / `Deep Research` / `Codex` (embedded VS Code extension in sidebar)
+
+- Modes: `Chat` / `Agent` / `Deep Research` / `Codex` (embedded VS Code extension in the sidebar)
 - Multi-provider support: OpenAI / Anthropic (Claude) / DeepSeek / Gemini / Moonshot / Groq / OpenRouter / Ollama
 - Local semantic retrieval (RAG) from your vault
 
 <h3 align="center">Editor and knowledge graph</h3>
+
 - Markdown source / live preview / reading modes
 - Bidirectional links with `[[WikiLinks]]`
-- LaTeX, Mermaid, code highlighting
+- LaTeX, Mermaid, and code highlighting
 - Graph visualization for relationships across notes
 
 <h3 align="center">Reading and capture</h3>
+
 - Built-in PDF reader with highlight, underline, and annotations
-- Save annotation results as Markdown
-- Send selected content directly to AI context
+- Save annotation output as Markdown
+- Send selected content directly into AI context
 
 <h3 align="center">Extra capabilities</h3>
-- Bilibili video notes (danmaku timestamp sync)
+
+- Bilibili video notes with danmaku timestamp sync
 - Real-time voice input
 - Database views (table / kanban)
 - WebDAV sync
@@ -93,6 +97,7 @@ Get the latest build from [Releases](https://github.com/blueberrycongee/Lumina-N
 - 15 themes
 
 <h3 align="center">Plugin ecosystem (Developer Preview)</h3>
+
 - Load plugins from workspace / user / built-in directories
 - Runtime permission model for plugin capabilities
 - Slash command extension API
@@ -104,7 +109,7 @@ Get the latest build from [Releases](https://github.com/blueberrycongee/Lumina-N
 
 1. Install Lumina Note from Releases.
 2. Choose a local folder as your vault on first launch.
-3. Configure model provider + API key in the right AI panel.
+3. Configure a model provider and API key in the AI panel.
 4. Create your first note and start linking with `[[WikiLinks]]`.
 
 ---
@@ -112,11 +117,13 @@ Get the latest build from [Releases](https://github.com/blueberrycongee/Lumina-N
 <h2 align="center">Guides</h2>
 
 <h3 align="center">Recommended user guides</h3>
+
 - English: `docs/user-flow.md`
 - 简体中文: `docs/user-flow.zh-CN.md`
 - 日本語: `docs/user-flow.ja.md`
 
 <h3 align="center">Self-hosted relay (cross-network mobile access)</h3>
+
 - English: `docs/self-host.md`
 - 简体中文: `docs/self-host.zh-CN.md`
 
@@ -125,6 +132,7 @@ Get the latest build from [Releases](https://github.com/blueberrycongee/Lumina-N
 <h2 align="center">Build from Source</h2>
 
 Requirements:
+
 - Node.js 20+ (recommended 20.11.1)
 - Rust 1.70+
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -1,0 +1,181 @@
+<div align="center">
+
+<img src="src-tauri/icons/128x128.png" alt="Lumina Note Logo" width="120" height="120" />
+
+# Lumina Note
+
+**Aplicativo de notas com IA e abordagem local-first**
+
+Suas notas permanecem no seu dispositivo. O Lumina Note ajuda você a escrever, conectar, buscar e refinar conhecimento com IA sem abrir mão do controle dos seus dados.
+
+[![GitHub Release](https://img.shields.io/github/v/release/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/releases)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg?style=flat-square)](LICENSE)
+[![Tauri](https://img.shields.io/badge/Tauri-v2-24C8DB?style=flat-square&logo=tauri&logoColor=white)](https://tauri.app/)
+
+[![CI](https://img.shields.io/github/actions/workflow/status/blueberrycongee/Lumina-Note/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/blueberrycongee/Lumina-Note/actions/workflows/ci.yml)
+[![Security Audit](https://img.shields.io/github/actions/workflow/status/blueberrycongee/Lumina-Note/security-audit.yml?branch=main&style=flat-square&label=Security%20Audit)](https://github.com/blueberrycongee/Lumina-Note/actions/workflows/security-audit.yml)
+[![Downloads](https://img.shields.io/github/downloads/blueberrycongee/Lumina-Note/total?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/releases)
+[![Last Commit](https://img.shields.io/github/last-commit/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/commits/main)
+[![GitHub Stars](https://img.shields.io/github/stars/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/stargazers)
+[![Commit Activity](https://img.shields.io/github/commit-activity/m/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/commits/main)
+![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS-lightgrey?style=flat-square)
+
+**Idioma**: [English](./README.md) · [简体中文](./README.zh-CN.md) · [繁體中文](./README.zh-TW.md) · [日本語](./README.ja.md) · [한국어](./README.ko.md) · [Español](./README.es.md) · [Français](./README.fr.md) · [Deutsch](./README.de.md) · [Italiano](./README.it.md) · Português (Brasil) · [Русский](./README.ru.md)
+
+</div>
+
+---
+
+<h2 align="center">Por que Lumina Note</h2>
+
+- **Projetado em local-first**: seu vault fica local e você decide o que será enviado aos provedores de modelos.
+- **Fluxo de trabalho centrado em conhecimento**: edição Markdown, WikiLinks, visualização em grafo e recuperação com IA funcionam como um único sistema.
+- **IA que realmente age**: `Chat`, `Agent`, `Deep Research` e `Codex` apoiam tarefas reais de edição e pesquisa.
+
+---
+
+<h2 align="center">Download</h2>
+
+<div align="center">
+
+Baixe a versão mais recente em [Releases](https://github.com/blueberrycongee/Lumina-Note/releases):
+
+| Plataforma | Pacote |
+|-----------|--------|
+| Windows | `.msi` / `.exe` |
+| macOS (Intel) | `x64.dmg` |
+| macOS (Apple Silicon) | `aarch64.dmg` |
+
+</div>
+
+---
+
+<h2 align="center">Capturas de tela</h2>
+
+<p align="center">
+  <img src="docs/screenshots/ai-agent.png" alt="AI Agent" width="800" />
+</p>
+
+<p align="center">
+  <img src="docs/screenshots/knowledge-graph.png" alt="Knowledge Graph" width="800" />
+</p>
+
+<p align="center">
+  <img src="docs/screenshots/editor-latex.png" alt="Editor" width="800" />
+</p>
+
+---
+
+<h2 align="center">Recursos</h2>
+
+<h3 align="center">Workspace de IA</h3>
+
+- Modos: `Chat` / `Agent` / `Deep Research` / `Codex` (extensão VS Code embutida na barra lateral)
+- Suporte a vários provedores: OpenAI / Anthropic (Claude) / DeepSeek / Gemini / Moonshot / Groq / OpenRouter / Ollama
+- Recuperação semântica local (RAG) a partir do seu vault
+
+<h3 align="center">Editor e grafo de conhecimento</h3>
+
+- Modos de código Markdown / preview ao vivo / leitura
+- Links bidirecionais com `[[WikiLinks]]`
+- LaTeX, Mermaid e destaque de código
+- Visualização em grafo das relações entre notas
+
+<h3 align="center">Leitura e captura</h3>
+
+- Leitor de PDF integrado com destaque, sublinhado e anotações
+- Salve resultados de anotação como Markdown
+- Envie conteúdo selecionado diretamente para o contexto da IA
+
+<h3 align="center">Capacidades extras</h3>
+
+- Notas de vídeo do Bilibili com sincronização de timestamp de danmaku
+- Entrada de voz em tempo real
+- Visualizações de banco de dados (tabela / kanban)
+- Sincronização WebDAV
+- Revisão com flashcards
+- 15 temas
+
+<h3 align="center">Ecossistema de plugins (Developer Preview)</h3>
+
+- Carregue plugins de diretórios workspace / user / built-in
+- Modelo de permissões em tempo de execução para capacidades de plugin
+- API de extensão Slash Command
+- Guia do desenvolvedor: `docs/plugin-ecosystem.md`
+
+---
+
+<h2 align="center">Início rápido</h2>
+
+1. Instale o Lumina Note a partir de Releases.
+2. Escolha uma pasta local como seu vault na primeira execução.
+3. Configure um provedor de modelos e sua API key no painel de IA.
+4. Crie sua primeira nota e comece a conectar com `[[WikiLinks]]`.
+
+---
+
+<h2 align="center">Guias</h2>
+
+<h3 align="center">Guias recomendados</h3>
+
+- English: `docs/user-flow.md`
+- 简体中文: `docs/user-flow.zh-CN.md`
+- 日本語: `docs/user-flow.ja.md`
+
+<h3 align="center">Relay self-hosted (acesso móvel entre redes)</h3>
+
+- English: `docs/self-host.md`
+- 简体中文: `docs/self-host.zh-CN.md`
+
+---
+
+<h2 align="center">Compilar a partir do código-fonte</h2>
+
+Requisitos:
+
+- Node.js 20+ (recomendado 20.11.1)
+- Rust 1.70+
+
+```bash
+git clone https://github.com/blueberrycongee/Lumina-Note.git
+cd Lumina-Note
+npm install
+npm run tauri dev
+```
+
+---
+
+<h2 align="center">Stack técnico</h2>
+
+- Framework: Tauri v2 (Rust + WebView)
+- Frontend: React 18, TypeScript, Tailwind CSS
+- Editor: CodeMirror 6
+- Gerenciamento de estado: Zustand
+- Armazenamento vetorial: SQLite
+
+---
+
+<h2 align="center">Componentes open source</h2>
+
+- Núcleo do editor: [codemirror-live-markdown](https://github.com/blueberrycongee/codemirror-live-markdown)
+- Runtime de orquestração em Rust: [forge](https://github.com/blueberrycongee/forge)
+
+---
+
+<h2 align="center">Contribuidores</h2>
+
+<a href="https://github.com/blueberrycongee/Lumina-Note/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=blueberrycongee/Lumina-Note" />
+</a>
+
+---
+
+<h2 align="center">Licença</h2>
+
+[Apache License 2.0](LICENSE)
+
+---
+
+<h2 align="center">Star History</h2>
+
+[![Star History Chart](https://api.star-history.com/svg?repos=blueberrycongee/Lumina-Note&type=Date)](https://star-history.com/#blueberrycongee/Lumina-Note&Date)

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,0 +1,181 @@
+<div align="center">
+
+<img src="src-tauri/icons/128x128.png" alt="Lumina Note Logo" width="120" height="120" />
+
+# Lumina Note
+
+**AI-приложение для заметок с подходом local-first**
+
+Ваши заметки остаются на вашем устройстве. Lumina Note помогает писать, связывать, искать и улучшать знания с помощью AI, сохраняя контроль над данными в ваших руках.
+
+[![GitHub Release](https://img.shields.io/github/v/release/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/releases)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg?style=flat-square)](LICENSE)
+[![Tauri](https://img.shields.io/badge/Tauri-v2-24C8DB?style=flat-square&logo=tauri&logoColor=white)](https://tauri.app/)
+
+[![CI](https://img.shields.io/github/actions/workflow/status/blueberrycongee/Lumina-Note/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/blueberrycongee/Lumina-Note/actions/workflows/ci.yml)
+[![Security Audit](https://img.shields.io/github/actions/workflow/status/blueberrycongee/Lumina-Note/security-audit.yml?branch=main&style=flat-square&label=Security%20Audit)](https://github.com/blueberrycongee/Lumina-Note/actions/workflows/security-audit.yml)
+[![Downloads](https://img.shields.io/github/downloads/blueberrycongee/Lumina-Note/total?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/releases)
+[![Last Commit](https://img.shields.io/github/last-commit/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/commits/main)
+[![GitHub Stars](https://img.shields.io/github/stars/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/stargazers)
+[![Commit Activity](https://img.shields.io/github/commit-activity/m/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/commits/main)
+![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS-lightgrey?style=flat-square)
+
+**Язык**: [English](./README.md) · [简体中文](./README.zh-CN.md) · [繁體中文](./README.zh-TW.md) · [日本語](./README.ja.md) · [한국어](./README.ko.md) · [Español](./README.es.md) · [Français](./README.fr.md) · [Deutsch](./README.de.md) · [Italiano](./README.it.md) · [Português (Brasil)](./README.pt-BR.md) · Русский
+
+</div>
+
+---
+
+<h2 align="center">Почему Lumina Note</h2>
+
+- **Архитектура local-first**: ваш vault хранится локально, и только вы решаете, что отправлять поставщикам моделей.
+- **Поток работы вокруг знаний**: Markdown-редактор, WikiLinks, граф и AI-поиск работают как единая система.
+- **AI, который действительно действует**: режимы `Chat`, `Agent`, `Deep Research` и `Codex` помогают с реальным редактированием и исследованием.
+
+---
+
+<h2 align="center">Загрузка</h2>
+
+<div align="center">
+
+Последнюю версию можно скачать в [Releases](https://github.com/blueberrycongee/Lumina-Note/releases):
+
+| Платформа | Пакет |
+|----------|-------|
+| Windows | `.msi` / `.exe` |
+| macOS (Intel) | `x64.dmg` |
+| macOS (Apple Silicon) | `aarch64.dmg` |
+
+</div>
+
+---
+
+<h2 align="center">Скриншоты</h2>
+
+<p align="center">
+  <img src="docs/screenshots/ai-agent.png" alt="AI Agent" width="800" />
+</p>
+
+<p align="center">
+  <img src="docs/screenshots/knowledge-graph.png" alt="Knowledge Graph" width="800" />
+</p>
+
+<p align="center">
+  <img src="docs/screenshots/editor-latex.png" alt="Editor" width="800" />
+</p>
+
+---
+
+<h2 align="center">Возможности</h2>
+
+<h3 align="center">AI workspace</h3>
+
+- Режимы: `Chat` / `Agent` / `Deep Research` / `Codex` (встроенное расширение VS Code в боковой панели)
+- Поддержка нескольких провайдеров: OpenAI / Anthropic (Claude) / DeepSeek / Gemini / Moonshot / Groq / OpenRouter / Ollama
+- Локальный семантический поиск (RAG) по вашему vault
+
+<h3 align="center">Редактор и граф знаний</h3>
+
+- Режимы исходного Markdown / живого предпросмотра / чтения
+- Двунаправленные ссылки через `[[WikiLinks]]`
+- LaTeX, Mermaid и подсветка кода
+- Графовая визуализация связей между заметками
+
+<h3 align="center">Чтение и сбор материалов</h3>
+
+- Встроенный PDF-ридер с подсветкой, подчеркиванием и аннотациями
+- Сохранение аннотаций в Markdown
+- Отправка выделенного содержимого прямо в контекст AI
+
+<h3 align="center">Дополнительные возможности</h3>
+
+- Заметки по видео Bilibili с синхронизацией таймкодов danmaku
+- Голосовой ввод в реальном времени
+- Представления базы данных (таблица / канбан)
+- Синхронизация WebDAV
+- Повторение с flashcards
+- 15 тем
+
+<h3 align="center">Экосистема плагинов (Developer Preview)</h3>
+
+- Загрузка плагинов из каталогов workspace / user / built-in
+- Модель runtime-разрешений для возможностей плагинов
+- API расширения Slash Command
+- Руководство для разработчиков: `docs/plugin-ecosystem.md`
+
+---
+
+<h2 align="center">Быстрый старт</h2>
+
+1. Установите Lumina Note из Releases.
+2. При первом запуске выберите локальную папку как ваш vault.
+3. Настройте провайдера модели и API key в AI-панели.
+4. Создайте первую заметку и начните связывать их через `[[WikiLinks]]`.
+
+---
+
+<h2 align="center">Руководства</h2>
+
+<h3 align="center">Рекомендуемые руководства</h3>
+
+- English: `docs/user-flow.md`
+- 简体中文: `docs/user-flow.zh-CN.md`
+- 日本語: `docs/user-flow.ja.md`
+
+<h3 align="center">Self-hosted relay (мобильный доступ через разные сети)</h3>
+
+- English: `docs/self-host.md`
+- 简体中文: `docs/self-host.zh-CN.md`
+
+---
+
+<h2 align="center">Сборка из исходников</h2>
+
+Требования:
+
+- Node.js 20+ (рекомендуется 20.11.1)
+- Rust 1.70+
+
+```bash
+git clone https://github.com/blueberrycongee/Lumina-Note.git
+cd Lumina-Note
+npm install
+npm run tauri dev
+```
+
+---
+
+<h2 align="center">Технологический стек</h2>
+
+- Framework: Tauri v2 (Rust + WebView)
+- Frontend: React 18, TypeScript, Tailwind CSS
+- Editor: CodeMirror 6
+- State management: Zustand
+- Vector storage: SQLite
+
+---
+
+<h2 align="center">Open source компоненты</h2>
+
+- Ядро редактора: [codemirror-live-markdown](https://github.com/blueberrycongee/codemirror-live-markdown)
+- Rust runtime для оркестрации: [forge](https://github.com/blueberrycongee/forge)
+
+---
+
+<h2 align="center">Участники</h2>
+
+<a href="https://github.com/blueberrycongee/Lumina-Note/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=blueberrycongee/Lumina-Note" />
+</a>
+
+---
+
+<h2 align="center">Лицензия</h2>
+
+[Apache License 2.0](LICENSE)
+
+---
+
+<h2 align="center">Star History</h2>
+
+[![Star History Chart](https://api.star-history.com/svg?repos=blueberrycongee/Lumina-Note&type=Date)](https://star-history.com/#blueberrycongee/Lumina-Note&Date)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,7 +6,7 @@
 
 **本地优先的 AI 笔记应用**
 
-笔记数据默认存储在你的设备上。Lumina Note 用 AI 帮你写作、整理、检索与沉淀知识，同时保持数据控制权。
+你的笔记默认保留在设备本地。Lumina Note 用 AI 帮你写作、连接、检索和整理知识，同时把数据控制权留在你手里。
 
 [![GitHub Release](https://img.shields.io/github/v/release/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg?style=flat-square)](LICENSE)
@@ -20,7 +20,7 @@
 [![Commit Activity](https://img.shields.io/github/commit-activity/m/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/commits/main)
 ![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS-lightgrey?style=flat-square)
 
-**Language**: [English](./README.md) · 简体中文 · [日本語](./README.ja.md)
+**语言**： [English](./README.md) · 简体中文 · [繁體中文](./README.zh-TW.md) · [日本語](./README.ja.md) · [한국어](./README.ko.md) · [Español](./README.es.md) · [Français](./README.fr.md) · [Deutsch](./README.de.md) · [Italiano](./README.it.md) · [Português (Brasil)](./README.pt-BR.md) · [Русский](./README.ru.md)
 
 </div>
 
@@ -28,9 +28,9 @@
 
 <h2 align="center">为什么选择 Lumina Note</h2>
 
-- **本地优先**：笔记库在本地，是否把内容发送给模型由你决定。
-- **知识工作流完整**：编辑器、双链、图谱是连在一起的，不是拼凑功能。
-- **AI 可执行任务**：不仅能聊天，还能完成检索、编辑、研究等实际工作。
+- **本地优先**：你的笔记库保留在本地，是否发送给模型服务商由你决定。
+- **围绕知识工作流设计**：Markdown 编辑、双链、图谱和 AI 检索是一个整体。
+- **AI 不只是聊天**：`Chat`、`Agent`、`Deep Research`、`Codex` 支持真实编辑与研究任务。
 
 ---
 
@@ -69,32 +69,37 @@
 <h2 align="center">功能概览</h2>
 
 <h3 align="center">AI 工作区</h3>
+
 - 模式：`Chat` / `Agent` / `Deep Research` / `Codex`（侧边栏内嵌 VS Code 扩展）
-- 支持多模型提供商：OpenAI / Anthropic (Claude) / DeepSeek / Gemini / Moonshot / Groq / OpenRouter / Ollama
+- 支持多模型服务商：OpenAI / Anthropic (Claude) / DeepSeek / Gemini / Moonshot / Groq / OpenRouter / Ollama
 - 基于本地笔记库的语义检索（RAG）
 
 <h3 align="center">编辑器与知识图谱</h3>
+
 - Markdown 源码 / 实时预览 / 阅读模式
 - `[[WikiLinks]]` 双向链接
 - LaTeX、Mermaid、代码高亮
-- 图谱可视化笔记关系
+- 图谱可视化笔记之间的关系
 
 <h3 align="center">阅读与采集</h3>
-- 内置 PDF 阅读器：高亮、下划线、批注
-- 批注可保存为 Markdown
+
+- 内置 PDF 阅读器，支持高亮、下划线和批注
+- 批注结果可保存为 Markdown
 - 选中内容可直接发送到 AI 上下文
 
 <h3 align="center">扩展能力</h3>
-- B 站视频笔记（弹幕时间戳同步）
-- 语音输入（实时转文字）
+
+- Bilibili 视频笔记，支持弹幕时间戳同步
+- 实时语音输入
 - 数据库视图（表格 / 看板）
 - WebDAV 同步
 - 闪卡复习
 - 15 套主题
 
 <h3 align="center">插件生态（开发者预览）</h3>
-- 从工作区 / 用户目录 / 内置目录加载插件
-- 插件能力运行时权限模型
+
+- 从 workspace / user / built-in 目录加载插件
+- 插件能力的运行时权限模型
 - Slash Command 扩展 API
 - 开发文档：`docs/plugin-ecosystem.md`
 
@@ -102,29 +107,32 @@
 
 <h2 align="center">快速开始</h2>
 
-1. 从 Releases 安装应用。
-2. 首次启动选择本地文件夹作为笔记库。
-3. 在右侧 AI 面板配置模型与 API Key。
-4. 创建第一条笔记，并用 `[[双链]]` 建立关联。
+1. 从 Releases 安装 Lumina Note。
+2. 首次启动时选择一个本地文件夹作为笔记库。
+3. 在 AI 面板中配置模型服务商和 API Key。
+4. 创建第一条笔记，并通过 `[[WikiLinks]]` 建立连接。
 
 ---
 
 <h2 align="center">使用指南</h2>
 
 <h3 align="center">推荐先读</h3>
-- 中文：`docs/user-flow.zh-CN.md`
+
 - English: `docs/user-flow.md`
+- 简体中文：`docs/user-flow.zh-CN.md`
 - 日本語: `docs/user-flow.ja.md`
 
 <h3 align="center">自部署中继（跨网络手机访问）</h3>
-- 中文：`docs/self-host.zh-CN.md`
+
 - English: `docs/self-host.md`
+- 简体中文：`docs/self-host.zh-CN.md`
 
 ---
 
 <h2 align="center">从源码构建</h2>
 
 环境要求：
+
 - Node.js 20+（推荐 20.11.1）
 - Rust 1.70+
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,0 +1,181 @@
+<div align="center">
+
+<img src="src-tauri/icons/128x128.png" alt="Lumina Note Logo" width="120" height="120" />
+
+# Lumina Note
+
+**本地優先的 AI 筆記應用**
+
+你的筆記預設保留在本機裝置上。Lumina Note 用 AI 幫你書寫、連結、檢索與整理知識，同時把資料控制權留在你手中。
+
+[![GitHub Release](https://img.shields.io/github/v/release/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/releases)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg?style=flat-square)](LICENSE)
+[![Tauri](https://img.shields.io/badge/Tauri-v2-24C8DB?style=flat-square&logo=tauri&logoColor=white)](https://tauri.app/)
+
+[![CI](https://img.shields.io/github/actions/workflow/status/blueberrycongee/Lumina-Note/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/blueberrycongee/Lumina-Note/actions/workflows/ci.yml)
+[![Security Audit](https://img.shields.io/github/actions/workflow/status/blueberrycongee/Lumina-Note/security-audit.yml?branch=main&style=flat-square&label=Security%20Audit)](https://github.com/blueberrycongee/Lumina-Note/actions/workflows/security-audit.yml)
+[![Downloads](https://img.shields.io/github/downloads/blueberrycongee/Lumina-Note/total?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/releases)
+[![Last Commit](https://img.shields.io/github/last-commit/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/commits/main)
+[![GitHub Stars](https://img.shields.io/github/stars/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/stargazers)
+[![Commit Activity](https://img.shields.io/github/commit-activity/m/blueberrycongee/Lumina-Note?style=flat-square)](https://github.com/blueberrycongee/Lumina-Note/commits/main)
+![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS-lightgrey?style=flat-square)
+
+**語言**： [English](./README.md) · [简体中文](./README.zh-CN.md) · 繁體中文 · [日本語](./README.ja.md) · [한국어](./README.ko.md) · [Español](./README.es.md) · [Français](./README.fr.md) · [Deutsch](./README.de.md) · [Italiano](./README.it.md) · [Português (Brasil)](./README.pt-BR.md) · [Русский](./README.ru.md)
+
+</div>
+
+---
+
+<h2 align="center">為什麼選擇 Lumina Note</h2>
+
+- **本地優先**：你的筆記庫保留在本地，是否送到模型服務商由你決定。
+- **圍繞知識工作流設計**：Markdown 編輯、雙向連結、圖譜與 AI 檢索是同一套系統。
+- **AI 不只是聊天**：`Chat`、`Agent`、`Deep Research`、`Codex` 支援真正的編輯與研究任務。
+
+---
+
+<h2 align="center">下載</h2>
+
+<div align="center">
+
+前往 [Releases](https://github.com/blueberrycongee/Lumina-Note/releases) 取得最新版本：
+
+| 平台 | 安裝包 |
+|------|--------|
+| Windows | `.msi` / `.exe` |
+| macOS (Intel) | `x64.dmg` |
+| macOS (Apple Silicon) | `aarch64.dmg` |
+
+</div>
+
+---
+
+<h2 align="center">畫面預覽</h2>
+
+<p align="center">
+  <img src="docs/screenshots/ai-agent.png" alt="AI Agent" width="800" />
+</p>
+
+<p align="center">
+  <img src="docs/screenshots/knowledge-graph.png" alt="知識圖譜" width="800" />
+</p>
+
+<p align="center">
+  <img src="docs/screenshots/editor-latex.png" alt="編輯器" width="800" />
+</p>
+
+---
+
+<h2 align="center">功能總覽</h2>
+
+<h3 align="center">AI 工作區</h3>
+
+- 模式：`Chat` / `Agent` / `Deep Research` / `Codex`（側欄內嵌 VS Code 擴充）
+- 支援多模型服務商：OpenAI / Anthropic (Claude) / DeepSeek / Gemini / Moonshot / Groq / OpenRouter / Ollama
+- 以本地筆記庫為基礎的語意檢索（RAG）
+
+<h3 align="center">編輯器與知識圖譜</h3>
+
+- Markdown 原始碼 / 即時預覽 / 閱讀模式
+- `[[WikiLinks]]` 雙向連結
+- LaTeX、Mermaid、程式碼高亮
+- 圖譜化呈現筆記之間的關係
+
+<h3 align="center">閱讀與擷取</h3>
+
+- 內建 PDF 閱讀器，支援螢光標記、底線與註解
+- 註解結果可儲存為 Markdown
+- 選取內容可直接送入 AI 上下文
+
+<h3 align="center">延伸能力</h3>
+
+- Bilibili 影片筆記，支援彈幕時間戳同步
+- 即時語音輸入
+- 資料庫視圖（表格 / 看板）
+- WebDAV 同步
+- 單字卡複習
+- 15 套主題
+
+<h3 align="center">外掛生態（開發者預覽）</h3>
+
+- 從 workspace / user / built-in 目錄載入外掛
+- 外掛能力的執行期權限模型
+- Slash Command 擴充 API
+- 開發文件：`docs/plugin-ecosystem.md`
+
+---
+
+<h2 align="center">快速開始</h2>
+
+1. 從 Releases 安裝 Lumina Note。
+2. 首次啟動時選擇本機資料夾作為筆記庫。
+3. 在 AI 面板中設定模型服務商與 API Key。
+4. 建立第一則筆記，並用 `[[WikiLinks]]` 串連知識。
+
+---
+
+<h2 align="center">使用指南</h2>
+
+<h3 align="center">建議先讀</h3>
+
+- English: `docs/user-flow.md`
+- 简体中文：`docs/user-flow.zh-CN.md`
+- 日本語: `docs/user-flow.ja.md`
+
+<h3 align="center">自架中繼（跨網路手機存取）</h3>
+
+- English: `docs/self-host.md`
+- 简体中文：`docs/self-host.zh-CN.md`
+
+---
+
+<h2 align="center">從原始碼建置</h2>
+
+環境需求：
+
+- Node.js 20+（建議 20.11.1）
+- Rust 1.70+
+
+```bash
+git clone https://github.com/blueberrycongee/Lumina-Note.git
+cd Lumina-Note
+npm install
+npm run tauri dev
+```
+
+---
+
+<h2 align="center">技術棧</h2>
+
+- 框架：Tauri v2（Rust + WebView）
+- 前端：React 18、TypeScript、Tailwind CSS
+- 編輯器：CodeMirror 6
+- 狀態管理：Zustand
+- 向量儲存：SQLite
+
+---
+
+<h2 align="center">開源元件</h2>
+
+- 編輯器核心：[codemirror-live-markdown](https://github.com/blueberrycongee/codemirror-live-markdown)
+- Rust 編排執行時：[forge](https://github.com/blueberrycongee/forge)
+
+---
+
+<h2 align="center">貢獻者</h2>
+
+<a href="https://github.com/blueberrycongee/Lumina-Note/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=blueberrycongee/Lumina-Note" />
+</a>
+
+---
+
+<h2 align="center">授權</h2>
+
+[Apache License 2.0](LICENSE)
+
+---
+
+<h2 align="center">Star History</h2>
+
+[![Star History Chart](https://api.star-history.com/svg?repos=blueberrycongee/Lumina-Note&type=Date)](https://star-history.com/#blueberrycongee/Lumina-Note&Date)


### PR DESCRIPTION
## Summary
- unify the main README structure across the existing English, Simplified Chinese, and Japanese variants
- add Traditional Chinese, Korean, Spanish, French, German, Italian, Portuguese (Brazil), and Russian README translations
- keep the language switcher consistent across all README variants to reduce drift

## Testing
- git diff --check
- no automated tests run (docs-only change)