### PR TITLE
fix(opencode): encode non-ASCII vault paths to prevent session creation failure

### DIFF
--- a/src/services/opencode/client.ts
+++ b/src/services/opencode/client.ts
@@ -72,7 +72,9 @@ export async function getOpencodeClient(): Promise<OpencodeClient> {
       authorization: buildAuthHeader(info),
     };
     if (defaultDirectory) {
-      headers["x-opencode-directory"] = defaultDirectory;
+      // encodeURI so non-ASCII characters (e.g. CJK paths) don't crash the
+      // browser Headers API which only accepts ISO-8859-1 code points.
+      headers["x-opencode-directory"] = encodeURI(defaultDirectory);
     }
     cachedClient = createOpencodeClient({
       baseUrl: info.url,

--- a/src/stores/useOpencodeAgent.ts
+++ b/src/stores/useOpencodeAgent.ts
@@ -757,7 +757,7 @@ export const useOpencodeAgent = create<OpencodeAgentStore>((set, get) => {
         // middleware spins up a different Instance — `sessions.get(id)`
         // hits a not-found path silently and the SSE stream goes dead.
         // Tie both calls to the same directory.
-        const query = directory ? { directory } : undefined;
+        const query = directory ? { directory: encodeURI(directory) } : undefined;
         const res = await client.session.create({ query, throwOnError: true });
         const data = res.data as { id?: string } | undefined;
         const id = data?.id ?? null;
@@ -922,7 +922,7 @@ export const useOpencodeAgent = create<OpencodeAgentStore>((set, get) => {
               path: { id: sessionId! },
               body: body as never,
               query: ctx?.workspace_path
-                ? { directory: ctx.workspace_path }
+                ? { directory: encodeURI(ctx.workspace_path) }
                 : undefined,
               throwOnError: true,
             }),


### PR DESCRIPTION
feat(opencode): encode directory path to support non-ASCII characters

Encode the x-opencode-directory header value using encodeURI to support non-ASCII characters like CJK paths, preventing crashes in the browser Headers API which only accepts ISO-8859-1 code points.
```