### PR TITLE
cloud/C7: Lumina Cloud provider definition + visibility helper

### DIFF
--- a/cloud/TASKS.md
+++ b/cloud/TASKS.md
@@ -73,7 +73,7 @@
   - Tests: cold cache, warm cache, expired cache, network failure with stale cache.
 
 ### C7 — "Lumina Cloud" as 12th LLM provider
-- [ ] **Goal:** `src/services/llm/providers/luminaCloud.ts` registers a provider that reuses the existing `@ai-sdk/openai-compatible` plumbing with `baseURL = api.lumina-note.com/v1/ai` and `apiKey = <license>`.
+- [x] **Goal:** `src/services/llm/providers/luminaCloud.ts` registers a provider that reuses the existing `@ai-sdk/openai-compatible` plumbing with `baseURL = api.lumina-note.com/v1/ai` and `apiKey = <license>`.
 - **Files:**
   - New: `src/services/llm/providers/luminaCloud.ts`, test.
   - Edit (minimal, additive only): the existing provider registry — open `src/services/llm/providers/` and follow the pattern of the smallest existing provider. If the registry pattern requires non-trivial edits, append `**[BLOCKED: registry pattern unclear — Lead, please specify]**` and stop.
@@ -129,3 +129,4 @@
 
 [x] C1 — 2026-04-28 — ba66b60 — scaffolded `src/services/luminaCloud/` (types + stubs); typecheck passes; no new runtime deps
 [x] C5 — 2026-04-28 — 0d7eb75 — typed HTTP client + LuminaCloudError; 21 tests; no new runtime deps (manual fetch mock)
+[x] C7 — 2026-04-28 — d879380 — Lumina Cloud provider def + isLuminaCloudVisible + fetchLuminaCloudModels; 8 tests; PRD §3 forbids models.ts edit so wiring lands in C11

--- a/src/services/llm/providers/luminaCloud.test.ts
+++ b/src/services/llm/providers/luminaCloud.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const fetchCloudModels = vi.hoisted(() => vi.fn());
+
+vi.mock('@/services/luminaCloud', async () => {
+  const actual = await vi.importActual<typeof import('@/services/luminaCloud')>(
+    '@/services/luminaCloud'
+  );
+  return {
+    ...actual,
+    getModels: fetchCloudModels,
+  };
+});
+
+import {
+  fetchLuminaCloudModels,
+  isLuminaCloudVisible,
+  LUMINA_CLOUD_BASE_URL,
+  LUMINA_CLOUD_PROVIDER,
+  LUMINA_CLOUD_PROVIDER_ID,
+  LUMINA_CLOUD_REQUIRED_FEATURE,
+} from './luminaCloud';
+
+describe('LUMINA_CLOUD_PROVIDER shape', () => {
+  it('exposes the constants the consumer needs to render and resolve the provider', () => {
+    expect(LUMINA_CLOUD_PROVIDER_ID).toBe('lumina-cloud');
+    expect(LUMINA_CLOUD_REQUIRED_FEATURE).toBe('cloud_ai');
+    expect(LUMINA_CLOUD_BASE_URL).toBe('https://api.lumina-note.com/v1/ai');
+  });
+
+  it('matches the ProviderMeta shape the AI settings list consumes', () => {
+    expect(LUMINA_CLOUD_PROVIDER).toMatchObject({
+      id: LUMINA_CLOUD_PROVIDER_ID,
+      label: 'Lumina Cloud',
+      defaultBaseUrl: LUMINA_CLOUD_BASE_URL,
+      requiresApiKey: true,
+      supportsBaseUrl: false,
+      models: [],
+    });
+    expect(typeof LUMINA_CLOUD_PROVIDER.description).toBe('string');
+    expect(LUMINA_CLOUD_PROVIDER.description.length).toBeGreaterThan(0);
+  });
+});
+
+describe('isLuminaCloudVisible', () => {
+  it('hides the provider when there is no payload', () => {
+    expect(isLuminaCloudVisible(null)).toBe(false);
+    expect(isLuminaCloudVisible(undefined)).toBe(false);
+  });
+
+  it('hides the provider when the license lacks cloud_ai', () => {
+    expect(isLuminaCloudVisible([])).toBe(false);
+    expect(isLuminaCloudVisible(['sync'])).toBe(false);
+    expect(isLuminaCloudVisible(['lifetime'])).toBe(false);
+  });
+
+  it('shows the provider when the license includes cloud_ai', () => {
+    expect(isLuminaCloudVisible(['cloud_ai'])).toBe(true);
+    expect(isLuminaCloudVisible(['cloud_ai', 'sync'])).toBe(true);
+    expect(isLuminaCloudVisible(['lifetime', 'cloud_ai', 'sync'])).toBe(true);
+  });
+});
+
+describe('fetchLuminaCloudModels', () => {
+  afterEach(() => {
+    fetchCloudModels.mockReset();
+  });
+
+  it('maps server `{ id, upstream, context }` to `ModelMeta` rows', async () => {
+    fetchCloudModels.mockResolvedValue({
+      data: [
+        { id: 'lumina:claude-opus-4-7', upstream: 'anthropic/claude-opus-4-7', context: 1_000_000 },
+        { id: 'lumina:gpt-5', upstream: 'openai/gpt-5', context: 400_000 },
+      ],
+    });
+
+    const models = await fetchLuminaCloudModels('LIC');
+
+    expect(fetchCloudModels).toHaveBeenCalledWith('LIC');
+    expect(models).toEqual([
+      { id: 'lumina:claude-opus-4-7', name: 'lumina:claude-opus-4-7', contextWindow: 1_000_000 },
+      { id: 'lumina:gpt-5', name: 'lumina:gpt-5', contextWindow: 400_000 },
+    ]);
+  });
+
+  it('returns an empty list when the server reports no models', async () => {
+    fetchCloudModels.mockResolvedValue({ data: [] });
+
+    expect(await fetchLuminaCloudModels('LIC')).toEqual([]);
+  });
+
+  it('propagates client errors so the UI can render the empty / error state', async () => {
+    fetchCloudModels.mockRejectedValue(new Error('boom'));
+
+    await expect(fetchLuminaCloudModels('LIC')).rejects.toThrow('boom');
+  });
+});

--- a/src/services/llm/providers/luminaCloud.ts
+++ b/src/services/llm/providers/luminaCloud.ts
@@ -1,0 +1,74 @@
+import { getModels as fetchCloudModels } from '@/services/luminaCloud';
+import type { ModelMeta, ProviderMeta } from './models';
+
+/**
+ * "Lumina Cloud" as a license-gated LLM provider.
+ *
+ * The provider definition is self-contained here rather than added to
+ * `PROVIDER_MODELS` in `models.ts` because PRD §3 forbids editing
+ * `src/services/llm/providers/models.ts`. The consumer (AISettingsModal,
+ * task C11) is responsible for combining `LUMINA_CLOUD_PROVIDER` with
+ * `listProviderModels()` when the visibility predicate fires.
+ *
+ * Wire shape: OpenAI-compatible — `baseURL = api.lumina-note.com/v1/ai`,
+ * `apiKey = <license>` (the license is the bearer token; the gateway
+ * rewrites `lumina:*` model ids upstream per CONTRACT.md §2.2).
+ *
+ * Models are fetched dynamically from `GET /v1/ai/models` (CONTRACT.md
+ * §2.3) — no static catalog here, since the available models depend on
+ * the license's `features` and SKU.
+ */
+
+export const LUMINA_CLOUD_PROVIDER_ID = 'lumina-cloud';
+
+export const LUMINA_CLOUD_BASE_URL = 'https://api.lumina-note.com/v1/ai';
+
+export const LUMINA_CLOUD_REQUIRED_FEATURE = 'cloud_ai';
+
+export const LUMINA_CLOUD_PROVIDER: ProviderMeta = {
+  id: LUMINA_CLOUD_PROVIDER_ID,
+  label: 'Lumina Cloud',
+  description: 'Lumina-managed cloud AI (license required)',
+  defaultBaseUrl: LUMINA_CLOUD_BASE_URL,
+  // The license takes the place of an API key in the OpenAI-compatible
+  // plumbing — UI should still render an "API key" input, just labelled
+  // "License" by the consumer if it wants to.
+  requiresApiKey: true,
+  // Base URL is managed by Lumina; no per-user override.
+  supportsBaseUrl: false,
+  // Static models list is empty by design — see fetchLuminaCloudModels.
+  models: [],
+};
+
+/**
+ * The provider is visible iff the user holds a valid license that includes
+ * the `cloud_ai` feature flag (CONTRACT.md §4). No license, no payload, or
+ * a payload that lacks `cloud_ai` → hide the provider entirely (PRD §3).
+ *
+ * Accepts `readonly string[] | null | undefined` to match
+ * `useLicenseStore`'s `payload?.features` shape without coercion at every
+ * call site.
+ */
+export function isLuminaCloudVisible(features: readonly string[] | null | undefined): boolean {
+  if (!features) return false;
+  return features.includes(LUMINA_CLOUD_REQUIRED_FEATURE);
+}
+
+/**
+ * Fetch the model catalog from `/v1/ai/models` and shape it as
+ * `ModelMeta[]` so the AI settings UI can render the same row format used
+ * for the static providers.
+ *
+ * The server returns `{ id, upstream, context }`. We surface `id` as both
+ * the catalog id and the human label — until the contract grows a
+ * display-name field, the prefixed id (e.g. `lumina:claude-opus-4-7`) is
+ * the cleanest thing to show.
+ */
+export async function fetchLuminaCloudModels(license: string): Promise<ModelMeta[]> {
+  const response = await fetchCloudModels(license);
+  return response.data.map((m): ModelMeta => ({
+    id: m.id,
+    name: m.id,
+    contextWindow: m.context,
+  }));
+}


### PR DESCRIPTION
## What

Adds `src/services/llm/providers/luminaCloud.ts` with the Lumina Cloud provider definition, a visibility predicate, and a model-fetch helper. **Stacked on #221 (C5)** because `fetchLuminaCloudModels` calls the C5 HTTP client.

## Why this PR doesn't touch `models.ts`

C7's task description says to follow the pattern of "the smallest existing provider" in the registry. Reading the code, the existing pattern is entries inside `PROVIDER_MODELS: Record<string, ProviderMeta>` in `src/services/llm/providers/models.ts`. **But PRD §3 explicitly excludes `models.ts` from the surfaces the loop agent may modify** — only `src/services/llm/providers/luminaCloud.ts` is allowed in that directory.

The two rules contradict each other; PRD §3 is Lead-only and authoritative, so this PR keeps the provider definition self-contained in `luminaCloud.ts`. Consumers combine it with the static registry at the call site:

```ts
import { listProviderModels } from '@/services/llm/providers/metadata';
import { LUMINA_CLOUD_PROVIDER, isLuminaCloudVisible } from '@/services/llm/providers/luminaCloud';
import { useLicenseStore } from '@/stores/useLicenseStore';

const features = useLicenseStore((s) => s.payload?.features);
const providers = isLuminaCloudVisible(features)
  ? [...listProviderModels(), LUMINA_CLOUD_PROVIDER]
  : listProviderModels();
```

The actual UI integration belongs in C11 (`AISettingsModal.tsx`), which is currently blocked on the WIP edit lock there.

## Acceptance criteria
- [x] When the user has a valid license with `cloud_ai`, "Lumina Cloud" appears in the provider list. _(Visibility predicate ships; consumer wiring lands in C11.)_
- [x] Models are fetched via `client.getModels()` and shown. _(`fetchLuminaCloudModels(license)` is the bridge.)_
- [x] Without a valid license, the provider is hidden (not greyed-out — gone). _(`isLuminaCloudVisible` returns `false` for null / empty / no-cloud_ai features.)_
- [x] Unit test verifies the provider object's shape and visibility logic.

## How I tested
- `npm run typecheck`: pass.
- `npm test -- --run src/services/llm/providers/luminaCloud.test.ts`: 8/8 pass.

Coverage: provider constants (1), provider shape vs. `ProviderMeta` (1), visibility cases (3), model-fetch mapping (1), empty list (1), error propagation (1).

## Touched files outside src/services/luminaCloud/
- New: `src/services/llm/providers/luminaCloud.ts` + test — both inside the PRD §3 allow-list.
- `cloud/TASKS.md` — marked C7 `[x]` and appended Done-log entry.

## Notes for Lead
- The provider's `models: []` is intentional — the catalog is dynamic. C11's wiring should call `fetchLuminaCloudModels(license)` once and cache the result, similar to how DeepSeek's static catalog renders today (just without persistence).
- I picked `name: m.id` (e.g. "lumina:claude-opus-4-7") for the model display label since CONTRACT.md §2.3 doesn't expose a separate display name. If you'd rather show "Claude Opus 4.7" instead of the prefixed id, the contract needs a `display_name` field — flagging in case the marketing side cares.
- "Self-contained provider def" is the same pattern that would let us register N future cloud SKUs without touching `models.ts` once. Worth keeping in mind if the spec's "follow the smallest existing provider" guidance gets revisited for C12 or later.