### PR TITLE
cloud/C10: BLOCKED — Account tab needs Lead clarification

### DIFF
--- a/cloud/TASKS.md
+++ b/cloud/TASKS.md
@@ -103,7 +103,7 @@
 - **Acceptance:** Tests cover three states (loading, success, error-with-cache).
 
 ### C10 — Mount the Account tab
-- [ ] **Goal:** Add an "Account" entry to the settings navigation that contains `LicenseSettings` + `CloudUsagePanel`.
+- [ ] **Goal:** Add an "Account" entry to the settings navigation that contains `LicenseSettings` + `CloudUsagePanel`. **[BLOCKED: settings nav lives in `src/components/layout/SettingsModal.tsx` which is outside the PRD §3 allow-list. Wiring is small (~8–10 additive lines + locale string), but the file is not modifiable. Lead, please confirm whether `layout/SettingsModal.tsx` may be edited or specify a different mount point.]**
 - **Approach:** Locate the existing settings nav. **If wiring it in requires more than ~10 lines of change in any single existing file, block and document where you stopped.**
 - **Acceptance:** "Account" tab appears, both panels render.
 
@@ -126,3 +126,5 @@
 ## Done log
 
 (Loop agent appends `[x] C<n> — <date> — <commit hash> — <one-line note>` here as tasks complete, mirroring the `[x]` above.)
+
+[BLOCKED] C10 — 2026-04-28 — settings nav at `src/components/layout/SettingsModal.tsx` is outside PRD §3 allow-list; ~8–10 additive lines but file not modifiable. Lead clarification requested.


### PR DESCRIPTION
## What

**Block, not implementation.** Per the rule "implementing the task would require editing a file outside `cloud/PRD.md` §3 surfaces, append [BLOCKED] and stop."

## The mismatch

The settings nav lives in `src/components/layout/SettingsModal.tsx`. It's a tabbed modal with `TAB_ORDER`, `TAB_ICONS`, and a `switch` in `renderContent`. Adding an Account tab needs:

```ts
type TabId = "general" | "ai" | "sync" | "network" | "system" | "account";

const TAB_ICONS: Record<TabId, typeof Settings> = {
  // …
  account: User,  // or similar
};

const TAB_ORDER: TabId[] = [..., "account"];

case "account":
  return (
    <>
      <LicenseSettings />
      <CloudUsagePanel />
    </>
  );
```

Plus the two imports and a locale string for `t.settingsModal.tabs.account`. About 8 additive lines in `SettingsModal.tsx`.

C10's own block-condition is "more than ~10 lines in any single existing file" — the wiring **fits** that budget. But **PRD §3** forbids edits outside the listed surfaces, and `src/components/layout/SettingsModal.tsx` isn't on the list. PRD §3 is Lead-only and authoritative, so this is a block.

## What I need from Lead

Pick one:
1. **Approve `src/components/layout/SettingsModal.tsx` edit** (~8 additive lines + a locale string). Lowest blast radius. Matches the existing tab pattern exactly.
2. **Specify a different mount point.** `AISettingsModal.tsx` is already on the allow-list (for minimal additive edits, reserved for C11). Mounting the Account panels inside the AI tab would conflict with the C10 spec ("settings navigation"), but it's an option.
3. **Add `src/components/layout/SettingsModal.tsx` to the PRD §3 allow-list** if Lead is OK widening the surface.

If you approve option 1, I'll unblock and ship the wiring in the next iteration. Components are ready: PR #224 (LicenseSettings) and PR #225 (CloudUsagePanel).

## Touched files
- `cloud/TASKS.md` only — appended the [BLOCKED] marker to the C10 task and added a Done-log entry. No code changes.

## Notes for Lead
- Branched from `main` so this block PR stands alone, doesn't depend on the C8/C9 stack, and can land or be dismissed without touching the rest.
- C11 (AISettingsModal additive edit) is also pre-blocked on WIP; both Account-tab-wiring and AISettingsModal-row-add will need a Lead pass once their respective gates clear.