### PR TITLE
cloud/C13: BLOCKED — README mention needs Lead clarification

### DIFF
--- a/cloud/TASKS.md
+++ b/cloud/TASKS.md
@@ -117,7 +117,7 @@
 - **Acceptance:** `npm test -- src/__tests__/luminaCloud.e2e.test.ts` passes.
 
 ### C13 — README mention (subtle, not pushy)
-- [ ] **Goal:** Add a small "Optional: Lumina Cloud (paid)" subsection under the Features section in `README.en.md` and `README.zh-CN.md` only.
+- [ ] **Goal:** Add a small "Optional: Lumina Cloud (paid)" subsection under the Features section in `README.en.md` and `README.zh-CN.md` only. **[BLOCKED: `README.en.md` and `README.zh-CN.md` are outside the PRD §3 allow-list. Lead, please confirm whether marketing-style README edits are exempt from §3 (intent of "blast radius" is code-internal) or specify a different mention surface.]**
 - **Tone:** Match the existing brand voice (quiet, precise — see `PRODUCT.md` §3). One paragraph max. Link to the marketing site (placeholder URL `https://lumina-note.com` for now).
 - **Acceptance:** Diff is ≤ 15 lines per file.
 
@@ -126,3 +126,5 @@
 ## Done log
 
 (Loop agent appends `[x] C<n> — <date> — <commit hash> — <one-line note>` here as tasks complete, mirroring the `[x]` above.)
+
+[BLOCKED] C13 — 2026-04-28 — `README.en.md` / `README.zh-CN.md` outside PRD §3 allow-list. Pure-docs edit, but rule applies. Lead clarification requested.


### PR DESCRIPTION
## What

**Block, not implementation.** Same shape as C10 (#226): C13 explicitly names files outside the PRD §3 allow-list.

## The mismatch

C13 says:
> Add a small "Optional: Lumina Cloud (paid)" subsection under the Features section in `README.en.md` and `README.zh-CN.md` only.

PRD §3 says:
> Outside `cloud/`, `src/services/luminaCloud/`, `src/services/llm/providers/luminaCloud.ts`, `src/components/settings/LicenseSettings.tsx`, `src/components/settings/CloudUsagePanel.tsx`, `src/stores/useLicenseStore.ts`, and minimal additive edits to `src/components/ai/AISettingsModal.tsx`, no other file may be modified by the loop agent for this initiative.

Both READMEs are outside the list. PRD §3's stated reason is "keeps blast radius small" — which is plausibly a code-internal concern that doesn't apply to documentation, but the literal rule applies to all files.

## What I need from Lead

Pick one:
1. **Approve the README edits.** The intent of §3 is code-internal blast radius; a one-paragraph marketing mention doesn't fit that risk model. If you confirm, I ship the diff in the next iteration (~10–15 lines per README, matching the existing brand voice — quiet, precise, single paragraph, link to the marketing site placeholder).
2. **Different mention surface.** Where would you want the cloud option mentioned in user-facing copy? `cloud/PRD.md` is Lead-only; `cloud/TASKS.md` isn't user-facing.
3. **Defer C13 to post-launch.** If marketing copy is supposed to land via a separate PR by the marketing/comms owner, mark C13 obsolete.

## Touched files
- `cloud/TASKS.md` only — appended the [BLOCKED] marker to the C13 task and added a Done-log entry. No code or doc changes.

## Notes for Lead
- This is the last unblocked P1 item. With C13 blocked, every P1 task is `[x]` or `[BLOCKED]` — the spec's "backlog drained" trigger fires next iteration.
- Three blocks total (C3 IPC plumbing, C10 settings nav, C13 README). All three are spec-vs-PRD-§3 tensions; none are implementation difficulty. Worth a single follow-up note on §3's exact intent.